### PR TITLE
Fix passing equipo data to JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,7 @@ El plugin registra el rol personalizado `empleado` y varias funciones auxiliares
 ### 1.0.1
 
 - Se añadió verificación de nonce y comprobación de capacidades al guardar la metabox "Equipo y Año" para mejorar la seguridad.
+
+### 1.0.2
+
+- Se corrigió el paso de datos de equipos a JavaScript para que se envíen como un array nativo en lugar de una cadena JSON.

--- a/cdb-empleado.php
+++ b/cdb-empleado.php
@@ -127,7 +127,7 @@ function cdb_empleado_admin_assets($hook) {
     wp_localize_script(
         'cdb-empleado-metabox',
         'cdbEmpleadoEquiposData',
-        wp_json_encode($equipos)
+        $equipos
     );
 
     wp_localize_script(


### PR DESCRIPTION
## Summary
- fix localized script to pass equipo data as array, not JSON string
- document change in changelog

## Testing
- `php -l cdb-empleado.php`

------
https://chatgpt.com/codex/tasks/task_e_688d28ebd5808327b5a2deb8c7784fa4