### PR TITLE
Inject employee chart into profile content

### DIFF
--- a/assets/css/perfil-empleado.css
+++ b/assets/css/perfil-empleado.css
@@ -1,0 +1,5 @@
+.cdb-empleado-grafica-wrap{margin:16px 0 24px}
+.cdb-empleado-grafica-notice{margin-top:10px;font-size:.9rem;color:#666}
+@media(min-width:1024px){
+  .cdb-empleado-grafica-wrap{float:right;max-width:520px;margin-left:24px}
+}

--- a/cdb-empleado.php
+++ b/cdb-empleado.php
@@ -140,6 +140,20 @@ function cdb_empleado_admin_assets($hook) {
 }
 add_action('admin_enqueue_scripts', 'cdb_empleado_admin_assets');
 
+/**
+ * Encolar estilos del perfil del empleado en el frontal.
+ */
+add_action('wp_enqueue_scripts', 'cdb_empleado_front_assets');
+function cdb_empleado_front_assets() {
+    if (!is_admin() && is_singular('empleado')) {
+        wp_enqueue_style(
+            'cdb-perfil-empleado',
+            plugins_url('assets/css/perfil-empleado.css', __FILE__),
+            array(),
+            '1.0.0'
+        );
+    }
+}
 
 /**
  * Render de la Metabox para asignar Equipo y Año.

--- a/inc/funciones-extra.php
+++ b/inc/funciones-extra.php
@@ -129,12 +129,32 @@ function cdb_equipos_del_empleado_registrar_shortcode() {
 }
 add_action('init', 'cdb_equipos_del_empleado_registrar_shortcode');
 
-// Inyectar el shortcode automáticamente en single-empleado
+// Inyectar automáticamente la gráfica y el listado de equipos en single-empleado
 function cdb_inyectar_equipos_del_empleado_en_contenido($content) {
-    if (is_singular('empleado') && in_the_loop() && is_main_query()) {
-        $shortcode_output = do_shortcode('[equipos_del_empleado]');
-        $content .= $shortcode_output;
+    $empleado_id = get_queried_object_id();
+    if (get_post_type($empleado_id) !== 'empleado' || !in_the_loop() || !is_main_query()) {
+        return $content;
     }
-    return $content;
+
+    if (false === apply_filters('cdb_empleado_inyectar_grafica', true, $empleado_id)) {
+        $grafica_block = '';
+    } else {
+        $attrs          = array('id_suffix' => 'content');
+        $grafica_html   = apply_filters('cdb_grafica_empleado_html', '', $empleado_id, $attrs);
+        $grafica_notice = apply_filters('cdb_grafica_empleado_notice', '', $empleado_id);
+
+        $grafica_block = '';
+        if (!empty($grafica_html)) {
+            $grafica_block  = '<div class="cdb-empleado-grafica-wrap">';
+            $grafica_block .= $grafica_html;
+            if (!empty($grafica_notice)) {
+                $grafica_block .= '<div class="cdb-empleado-grafica-notice">' . $grafica_notice . '</div>';
+            }
+            $grafica_block .= '</div>';
+        }
+    }
+
+    $shortcode_output = do_shortcode('[equipos_del_empleado empleado_id="' . $empleado_id . '"]');
+    return $content . $grafica_block . $shortcode_output;
 }
 add_filter('the_content', 'cdb_inyectar_equipos_del_empleado_en_contenido');


### PR DESCRIPTION
## Summary
- Load new profile CSS only on single employee pages
- Inject employee chart HTML via cdb-grafica API before team list
- Allow disabling chart injection with filter

## Testing
- `php -l inc/funciones-extra.php`
- `php -l cdb-empleado.php`


------
https://chatgpt.com/codex/tasks/task_e_689a768fe9908327a92fd950c3d7dbd0