### PR TITLE
Mostrar formulario de calificación de empleado

### DIFF
--- a/assets/css/perfil-empleado.css
+++ b/assets/css/perfil-empleado.css
@@ -3,3 +3,5 @@
 @media(min-width:1024px){
   .cdb-empleado-grafica-wrap{float:right;max-width:520px;margin-left:24px}
 }
+
+.cdb-empleado-calificacion-wrap{clear:both;margin:24px 0}

--- a/inc/funciones-extra.php
+++ b/inc/funciones-extra.php
@@ -154,7 +154,15 @@ function cdb_inyectar_equipos_del_empleado_en_contenido($content) {
         }
     }
 
+    $calificacion_block = '';
+    if ( true === apply_filters('cdb_empleado_inyectar_calificacion', true, $empleado_id) ) {
+        $form_html = apply_filters('cdb_grafica_empleado_form_html', '', $empleado_id, array('id_suffix' => 'content'));
+        if ( ! empty($form_html) ) {
+            $calificacion_block = '<div class="cdb-empleado-calificacion-wrap">' . $form_html . '</div>';
+        }
+    }
+
     $shortcode_output = do_shortcode('[equipos_del_empleado empleado_id="' . $empleado_id . '"]');
-    return $content . $grafica_block . $shortcode_output;
+    return $content . $grafica_block . $calificacion_block . $shortcode_output;
 }
 add_filter('the_content', 'cdb_inyectar_equipos_del_empleado_en_contenido');


### PR DESCRIPTION
## Resumen
- Se inyecta un bloque con el formulario de calificación del empleado debajo de la gráfica, controlado por filtros para habilitar/deshabilitar y para obtener el HTML del formulario.
- Se agrega estilo para el contenedor de calificación.

## Testing
- `php -l inc/funciones-extra.php`

------
https://chatgpt.com/codex/tasks/task_e_689a84ee1e2c8327904b79603ab11f8f