### PR TITLE
Mostrar aviso si el formulario de calificación está vacío

### DIFF
--- a/inc/funciones-extra.php
+++ b/inc/funciones-extra.php
@@ -157,8 +157,15 @@ function cdb_inyectar_equipos_del_empleado_en_contenido($content) {
     $calificacion_block = '';
     if ( true === apply_filters('cdb_empleado_inyectar_calificacion', true, $empleado_id) ) {
         $form_html = apply_filters('cdb_grafica_empleado_form_html', '', $empleado_id, array('id_suffix' => 'content'));
+
         if ( ! empty($form_html) ) {
             $calificacion_block = '<div class="cdb-empleado-calificacion-wrap">' . $form_html . '</div>';
+        } else {
+            // Fallback: pedir el aviso y pintarlo si existe
+            $form_notice = apply_filters('cdb_grafica_empleado_notice', '', $empleado_id);
+            if ( ! empty($form_notice) ) {
+                $calificacion_block = '<div class="cdb-empleado-calificacion-wrap">' . $form_notice . '</div>';
+            }
         }
     }
 


### PR DESCRIPTION
## Resumen
- Muestra aviso si el formulario de calificación no devuelve contenido.
- Mantiene la visualización de la gráfica y el listado de equipos sin cambios.

## Testing
- `phpunit` *(falla: command not found)*
- `composer test` *(falla: command "test" is not defined)*
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a90b59f8083279c597b59477d589f