### PR TITLE
Centrar columnas numéricas en calificación de empleados

### DIFF
--- a/assets/css/perfil-empleado.css
+++ b/assets/css/perfil-empleado.css
@@ -20,3 +20,15 @@
 
 /* Sección inferior */
 .cdb-empleado-calificacion-wrap{clear:both;margin:24px 0}
+
+/* Tabla de calificaciones: centrar columnas numéricas */
+.cdb-empleado-calificacion-wrap table thead th:nth-child(n+2),
+.cdb-empleado-calificacion-wrap table tbody td:nth-child(n+2) {
+  text-align: center;
+}
+
+/* Mantener la 1ª columna (Criterio) alineada a la izquierda */
+.cdb-empleado-calificacion-wrap table thead th:first-child,
+.cdb-empleado-calificacion-wrap table tbody td:first-child {
+  text-align: left;
+}


### PR DESCRIPTION
## Summary
- Centra las columnas numéricas de la tabla de calificación de empleados.
- Mantiene alineada a la izquierda la columna de criterios.

## Testing
- `npm test` *(falla: no se encontró package.json)*
- `composer test` *(falla: Command "test" is not defined.)*

------
https://chatgpt.com/codex/tasks/task_e_689b0fa29e2083278b487e7ee5de7e8b