### PR TITLE
Centrado preciso de columnas en la tabla de calificación

### DIFF
--- a/assets/css/perfil-empleado.css
+++ b/assets/css/perfil-empleado.css
@@ -61,3 +61,39 @@
     white-space: nowrap;
   }
 }
+
+/* === Tabla de calificación (marcada por cdb-grafica) === */
+.cdb-empleado-calificacion-wrap table.cdb-grafica-scores{
+  width:100%;
+  border-collapse:collapse;
+}
+
+/* Primera columna (Criterio) SIEMPRE a la izquierda */
+.cdb-empleado-calificacion-wrap table.cdb-grafica-scores thead th:first-child,
+.cdb-empleado-calificacion-wrap table.cdb-grafica-scores tbody th[scope="row"]{
+  text-align:left !important;
+}
+
+/* Cabeceras 2–4 centradas */
+.cdb-empleado-calificacion-wrap table.cdb-grafica-scores thead th:nth-child(2),
+.cdb-empleado-calificacion-wrap table.cdb-grafica-scores thead th:nth-child(3),
+.cdb-empleado-calificacion-wrap table.cdb-grafica-scores thead th:nth-child(4){
+  text-align:center !important;
+}
+
+/* Celdas de datos 2–4 centradas */
+.cdb-empleado-calificacion-wrap table.cdb-grafica-scores tbody td:nth-child(2),
+.cdb-empleado-calificacion-wrap table.cdb-grafica-scores tbody td:nth-child(3),
+.cdb-empleado-calificacion-wrap table.cdb-grafica-scores tbody td:nth-child(4){
+  text-align:center !important;
+  vertical-align:middle;
+}
+
+/* (Opcional) Evitar cortes raros en móvil */
+@media (max-width:480px){
+  .cdb-empleado-calificacion-wrap table.cdb-grafica-scores tbody th[scope="row"]{
+    white-space:nowrap;
+    padding-right:8px;
+  }
+}
+


### PR DESCRIPTION
## Summary
- Ajusta la especificidad de la tabla `.cdb-grafica-scores` para centrar las columnas de valores y mantener la columna de criterios alineada a la izquierda.
- Añade mejoras móviles para evitar cortes en la primera columna.

## Testing
- `npm test` *(falla: no se encontró `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_689bd68edb388327842af7a7a86b1724