### PR TITLE
Mostrar puntuación total en tarjeta del empleado

### DIFF
--- a/assets/css/perfil-empleado.css
+++ b/assets/css/perfil-empleado.css
@@ -85,15 +85,21 @@
 .cdb-empleado-calificacion-wrap table.cdb-grafica-scores tbody td:nth-child(2),
 .cdb-empleado-calificacion-wrap table.cdb-grafica-scores tbody td:nth-child(3),
 .cdb-empleado-calificacion-wrap table.cdb-grafica-scores tbody td:nth-child(4){
-  text-align:center !important;
-  vertical-align:middle;
+    text-align:center !important;
+    vertical-align:middle;
 }
 
 /* (Opcional) Evitar cortes raros en móvil */
 @media (max-width:480px){
-  .cdb-empleado-calificacion-wrap table.cdb-grafica-scores tbody th[scope="row"]{
-    white-space:nowrap;
-    padding-right:8px;
+    .cdb-empleado-calificacion-wrap table.cdb-grafica-scores tbody th[scope="row"]{
+      white-space:nowrap;
+      padding-right:8px;
+    }
   }
+
+.cdb-empleado-card__score{
+  display:inline-block; margin-top:8px; padding:4px 10px;
+  border-radius:9999px; background:#111; color:#fff; font-weight:700;
+  font-variant-numeric: tabular-nums;
 }
 

--- a/inc/funciones-extra.php
+++ b/inc/funciones-extra.php
@@ -150,6 +150,7 @@ function cdb_inyectar_equipos_del_empleado_en_contenido($content) {
 
         $empleado_author = (int) get_post_field('post_author', $empleado_id);
         $disponible      = ('1' === get_post_meta($empleado_id, 'disponible', true));
+        $total           = (float) apply_filters('cdb_grafica_empleado_total', 0, $empleado_id);
 
         $card_html  = '<div class="cdb-empleado-card">';
         $card_html .= '<div class="cdb-empleado-card__avatar">' . get_avatar($empleado_author, 96) . '</div>';
@@ -157,7 +158,8 @@ function cdb_inyectar_equipos_del_empleado_en_contenido($content) {
         $card_html .= '<div class="cdb-pill ' . ($disponible ? 'ok' : 'off') . '">';
         $card_html .= $disponible ? __('Disponible', 'cdb-empleado') : __('No disponible', 'cdb-empleado');
         $card_html .= '</div>';
-        $card_html .= '<div class="cdb-empleado-card__total">' . esc_html( apply_filters('cdb_grafica_empleado_total', 0, $empleado_id) ) . '</div>';
+        $card_html .= '<div class="cdb-empleado-card__score" aria-label="Puntuación total">'
+                    .  number_format_i18n($total, 0) . '</div>';
         $card_html .= '</div>';
 
         $hero  = '<section class="cdb-empleado-hero">';


### PR DESCRIPTION
## Summary
- Calcula y muestra la puntuación total del empleado en su tarjeta de perfil
- Añade estilos para el marcador de puntuación total

## Testing
- `php -l inc/funciones-extra.php`


------
https://chatgpt.com/codex/tasks/task_e_689c5c9539fc8327945e97f90528d3af