### PR TITLE
Separar hero de calificación y ajustar layout del perfil de empleado

### DIFF
--- a/assets/css/perfil-empleado.css
+++ b/assets/css/perfil-empleado.css
@@ -1,7 +1,7 @@
 /* Layout superior */
-.cdb-empleado-hero{display:grid;grid-template-columns:1fr;gap:16px;margin:12px 0 20px}
-@media (min-width:1024px){
-  .cdb-empleado-hero{grid-template-columns:360px 1fr;align-items:start}
+.cdb-empleado-hero{display:grid;grid-template-columns:minmax(280px,360px) 1fr;gap:16px;align-items:start;margin:12px 0 20px}
+@media (max-width:1023px){
+  .cdb-empleado-hero{grid-template-columns:1fr}
 }
 
 /* Tarjeta */
@@ -14,12 +14,13 @@
 .cdb-empleado-card__total{margin-top:10px;font-weight:600}
 
 /* Gráfica */
-.cdb-empleado-grafica-wrap{margin:0}           /* Quita márgenes y float anteriores */
+.cdb-empleado-grafica-wrap{margin:0;float:none!important}           /* Quita márgenes y float anteriores */
 .cdb-empleado-grafica-notice{margin-top:10px;font-size:.9rem;color:#666}
 @media (min-width:1024px){ .cdb-empleado-grafica-wrap{margin:0} }
 
 /* Sección inferior */
 .cdb-empleado-calificacion-wrap{clear:both;margin:24px 0}
+.cdb-empleado-hero .cdb-empleado-calificacion-wrap{grid-column:1/-1}
 
 /* Tabla de calificaciones: centrar columnas numéricas */
 .cdb-empleado-calificacion-wrap table thead th:nth-child(n+2),

--- a/inc/funciones-extra.php
+++ b/inc/funciones-extra.php
@@ -143,7 +143,7 @@ function cdb_inyectar_equipos_del_empleado_en_contenido($content) {
     }
 
     if (false === apply_filters('cdb_empleado_inyectar_grafica', true, $empleado_id)) {
-        $hero = '';
+        $hero_html = '';
     } else {
         $attrs        = array('id_suffix' => 'content');
         $grafica_html = apply_filters('cdb_grafica_empleado_html', '', $empleado_id, $attrs);
@@ -162,10 +162,10 @@ function cdb_inyectar_equipos_del_empleado_en_contenido($content) {
                     .  number_format_i18n($total, 0) . '</div>';
         $card_html .= '</div>';
 
-        $hero  = '<section class="cdb-empleado-hero">';
-        $hero .= $card_html;
-        $hero .= '<div class="cdb-empleado-grafica-wrap">' . $grafica_html . '</div>';
-        $hero .= '</section>';
+        $hero_html  = '<section class="cdb-empleado-hero">';
+        $hero_html .= $card_html;
+        $hero_html .= '<div class="cdb-empleado-grafica-wrap">' . $grafica_html . '</div>';
+        $hero_html .= '</section>';
     }
 
     $calificacion_block = '';
@@ -184,6 +184,6 @@ function cdb_inyectar_equipos_del_empleado_en_contenido($content) {
     }
 
     $shortcode_output = do_shortcode('[equipos_del_empleado empleado_id="' . $empleado_id . '"]');
-    return $content . $hero . $calificacion_block . $shortcode_output;
+    return $content . $hero_html . $calificacion_block . $shortcode_output;
 }
 add_filter('the_content', 'cdb_inyectar_equipos_del_empleado_en_contenido');


### PR DESCRIPTION
## Resumen
- Separa el bloque de hero de la tabla/formulario de calificación.
- Ajusta estilos para que el hero mantenga su grid y la tabla ocupe todo el ancho.
- Neutraliza floats heredados en la gráfica.

## Testing
- `php -l inc/funciones-extra.php`
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d1850c0048327a3cbb6e66ddb091a