### PR TITLE
Mostrar tabla de calificaciones en perfil

### DIFF
--- a/assets/css/perfil-empleado.css
+++ b/assets/css/perfil-empleado.css
@@ -20,7 +20,6 @@
 
 /* Sección inferior */
 .cdb-empleado-calificacion-wrap{clear:both;margin:24px 0}
-.cdb-empleado-hero .cdb-empleado-calificacion-wrap{grid-column:1/-1}
 
 /* Tabla de calificaciones: centrar columnas numéricas */
 .cdb-empleado-calificacion-wrap table thead th:nth-child(n+2),

--- a/inc/funciones-extra.php
+++ b/inc/funciones-extra.php
@@ -170,14 +170,16 @@ function cdb_inyectar_equipos_del_empleado_en_contenido($content) {
 
     $calificacion_block = '';
     if ( true === apply_filters('cdb_empleado_inyectar_calificacion', true, $empleado_id) ) {
+        $args_common = array('id_suffix' => 'content', 'embed_chart' => false);
         if ( $is_self ) {
-            $body_html = apply_filters('cdb_grafica_empleado_scores_table_html', '', $empleado_id);
+            $body_html = apply_filters('cdb_grafica_empleado_scores_table_html', '', $empleado_id, array('with_legend' => true));
         } else {
-            $body_html = apply_filters('cdb_grafica_empleado_form_html', '', $empleado_id, array('embed_chart' => false, 'id_suffix' => 'content'));
-        }
-
-        if ( empty($body_html) ) {
-            $body_html = apply_filters('cdb_grafica_empleado_notice', '', $empleado_id);
+            $can_rate = current_user_can('submit_grafica_empleado');
+            if ( $can_rate ) {
+                $body_html = apply_filters('cdb_grafica_empleado_form_html', '', $empleado_id, $args_common);
+            } else {
+                $body_html = apply_filters('cdb_grafica_empleado_scores_table_html', '', $empleado_id, array('with_legend' => true));
+            }
         }
 
         $calificacion_block = '<div class="cdb-empleado-calificacion-wrap">' . $body_html . '</div>';


### PR DESCRIPTION
## Summary
- Mostrar tabla agregada en el perfil propio.
- Elegir entre formulario o tabla al ver perfiles de otros, según la capacidad `submit_grafica_empleado`.
- Simplificar estilos del bloque de calificación al separar del hero.

## Testing
- `php -l inc/funciones-extra.php`
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689d28dc5db483279366046108b81554