### PR TITLE
Show notice when user cannot rate employee

### DIFF
--- a/inc/funciones-extra.php
+++ b/inc/funciones-extra.php
@@ -171,14 +171,20 @@ function cdb_inyectar_equipos_del_empleado_en_contenido($content) {
     $calificacion_block = '';
     if ( true === apply_filters('cdb_empleado_inyectar_calificacion', true, $empleado_id) ) {
         $args_common = array('id_suffix' => 'content', 'embed_chart' => false);
+
         if ( $is_self ) {
+            // Solo lectura (misma tabla que el form)
             $body_html = apply_filters('cdb_grafica_empleado_scores_table_html', '', $empleado_id, array('with_legend' => true));
         } else {
-            $can_rate = current_user_can('submit_grafica_empleado');
+            $can_rate = current_user_can('submit_grafica_empleado'); // capacidad actual del proyecto
             if ( $can_rate ) {
                 $body_html = apply_filters('cdb_grafica_empleado_form_html', '', $empleado_id, $args_common);
             } else {
-                $body_html = apply_filters('cdb_grafica_empleado_scores_table_html', '', $empleado_id, array('with_legend' => true));
+                // ✅ usar el aviso oficial; si algún sitio lo anula, fallback a tabla de lectura
+                $notice    = apply_filters('cdb_grafica_empleado_notice', '', $empleado_id);
+                $body_html = ! empty( $notice )
+                    ? '<div class="cdb-grafica-empleado-notice">' . $notice . '</div>'
+                    : apply_filters('cdb_grafica_empleado_scores_table_html', '', $empleado_id, array('with_legend' => true));
             }
         }
 


### PR DESCRIPTION
## Summary
- display official rating notice on employee pages when current user lacks permission
- fall back to read-only scores table if notice is disabled

## Testing
- `php -l inc/funciones-extra.php`


------
https://chatgpt.com/codex/tasks/task_e_689e05e438488327a6e592ba6182c65e