### PR TITLE
Restringe reglas de alineación a tablas antiguas

### DIFF
--- a/assets/css/perfil-empleado.css
+++ b/assets/css/perfil-empleado.css
@@ -21,46 +21,27 @@
 /* Sección inferior */
 .cdb-empleado-calificacion-wrap{clear:both;margin:24px 0}
 
-/* Tabla de calificaciones: centrar columnas numéricas */
-.cdb-empleado-calificacion-wrap table thead th:nth-child(n+2),
-.cdb-empleado-calificacion-wrap table tbody td:nth-child(n+2) {
-  text-align: center;
+/* ⚠️ Reglas de alineación: aplicar SOLO a tablas que no sean la unificada de cdb-grafica */
+.cdb-empleado-calificacion-wrap table:not(.cdb-grafica-scores){
+  width:100%;
+  border-collapse:collapse;
+}
+.cdb-empleado-calificacion-wrap table:not(.cdb-grafica-scores) thead th:first-child,
+.cdb-empleado-calificacion-wrap table:not(.cdb-grafica-scores) tbody th[scope="row"]{
+  text-align:left !important;
+}
+.cdb-empleado-calificacion-wrap table:not(.cdb-grafica-scores) thead th:nth-child(2),
+.cdb-empleado-calificacion-wrap table:not(.cdb-grafica-scores) thead th:nth-child(3),
+.cdb-empleado-calificacion-wrap table:not(.cdb-grafica-scores) thead th:nth-child(4),
+.cdb-empleado-calificacion-wrap table:not(.cdb-grafica-scores) tbody td:nth-child(2),
+.cdb-empleado-calificacion-wrap table:not(.cdb-grafica-scores) tbody td:nth-child(3),
+.cdb-empleado-calificacion-wrap table:not(.cdb-grafica-scores) tbody td:nth-child(4){
+  text-align:center !important;
+  vertical-align:middle;
 }
 
-/* Mantener la 1ª columna (Criterio) alineada a la izquierda */
-.cdb-empleado-calificacion-wrap table thead th:first-child,
-.cdb-empleado-calificacion-wrap table tbody td:first-child {
-  text-align: left;
-}
-/* ---- Tabla de calificaciones (centrado robusto) ---- */
-.cdb-empleado-calificacion-wrap table {
-  width: 100%;
-  border-collapse: collapse;
-}
-
-.cdb-empleado-calificacion-wrap table thead th:first-child,
-.cdb-empleado-calificacion-wrap table tbody td:first-child {
-  text-align: left !important;       /* Criterio a la izquierda */
-}
-
-.cdb-empleado-calificacion-wrap table thead th:nth-child(2),
-.cdb-empleado-calificacion-wrap table thead th:nth-child(3),
-.cdb-empleado-calificacion-wrap table thead th:nth-child(4),
-.cdb-empleado-calificacion-wrap table tbody td:nth-child(2),
-.cdb-empleado-calificacion-wrap table tbody td:nth-child(3),
-.cdb-empleado-calificacion-wrap table tbody td:nth-child(4) {
-  text-align: center !important;      /* Forzar centrado en valores */
-  vertical-align: middle;
-}
-
-/* (Opcional) Dar algo de aire a la columna de criterios en móvil */
-@media (max-width: 480px){
-  .cdb-empleado-calificacion-wrap table thead th:first-child,
-  .cdb-empleado-calificacion-wrap table tbody td:first-child {
-    padding-right: 8px;
-    white-space: nowrap;
-  }
-}
+/* (Opcional) margen de la leyenda/tablas unificadas */
+.cdb-scores-legend{ margin:8px 0 12px; }
 
 /* === Tabla de calificación (marcada por cdb-grafica) === */
 .cdb-empleado-calificacion-wrap table.cdb-grafica-scores{


### PR DESCRIPTION
## Summary
- Evita que las reglas globales de alineación afecten a la tabla unificada `cdb-grafica-scores`
- Añade margen opcional para la leyenda de tablas unificadas

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e090cad1c8327b969e9159eef56f5