### PR TITLE
Use grafica filters for score table

### DIFF
--- a/assets/css/perfil-empleado.css
+++ b/assets/css/perfil-empleado.css
@@ -12,78 +12,12 @@
 .cdb-pill.ok{background:#eaf7ef;color:#1f7a3d}
 .cdb-pill.off{background:#f8eaea;color:#a23434}
 .cdb-empleado-card__total{margin-top:10px;font-weight:600}
+.cdb-empleado-card__score{display:inline-block;margin-top:8px;padding:4px 10px;border-radius:9999px;background:#111;color:#fff;font-weight:700;font-variant-numeric:tabular-nums}
 
 /* Gráfica */
-.cdb-empleado-grafica-wrap{margin:0;float:none!important}           /* Quita márgenes y float anteriores */
+.cdb-empleado-grafica-wrap{float:none}
 .cdb-empleado-grafica-notice{margin-top:10px;font-size:.9rem;color:#666}
-@media (min-width:1024px){ .cdb-empleado-grafica-wrap{margin:0} }
 
 /* Sección inferior */
-.cdb-empleado-calificacion-wrap{clear:both;margin:24px 0}
-
-/* ⚠️ Reglas de alineación: aplicar SOLO a tablas que no sean la unificada de cdb-grafica */
-.cdb-empleado-calificacion-wrap table:not(.cdb-grafica-scores){
-  width:100%;
-  border-collapse:collapse;
-}
-.cdb-empleado-calificacion-wrap table:not(.cdb-grafica-scores) thead th:first-child,
-.cdb-empleado-calificacion-wrap table:not(.cdb-grafica-scores) tbody th[scope="row"]{
-  text-align:left !important;
-}
-.cdb-empleado-calificacion-wrap table:not(.cdb-grafica-scores) thead th:nth-child(2),
-.cdb-empleado-calificacion-wrap table:not(.cdb-grafica-scores) thead th:nth-child(3),
-.cdb-empleado-calificacion-wrap table:not(.cdb-grafica-scores) thead th:nth-child(4),
-.cdb-empleado-calificacion-wrap table:not(.cdb-grafica-scores) tbody td:nth-child(2),
-.cdb-empleado-calificacion-wrap table:not(.cdb-grafica-scores) tbody td:nth-child(3),
-.cdb-empleado-calificacion-wrap table:not(.cdb-grafica-scores) tbody td:nth-child(4){
-  text-align:center !important;
-  vertical-align:middle;
-}
-
-/* Card contenedora de la tabla unificada */
-.cdb-scores-card{background:#fff7e6;/* adapta si tu tema usa otro tono */ border:1px solid rgba(0,0,0,.06);border-radius:12px;padding:16px;margin:16px 0 24px}
-
-/* (Opcional) margen de la leyenda/tablas unificadas */
-.cdb-scores-legend{ margin:8px 0 12px; }
-
-/* === Tabla de calificación (marcada por cdb-grafica) === */
-.cdb-empleado-calificacion-wrap table.cdb-grafica-scores{
-  width:100%;
-  border-collapse:collapse;
-}
-
-/* Primera columna (Criterio) SIEMPRE a la izquierda */
-.cdb-empleado-calificacion-wrap table.cdb-grafica-scores thead th:first-child,
-.cdb-empleado-calificacion-wrap table.cdb-grafica-scores tbody th[scope="row"]{
-  text-align:left !important;
-}
-
-/* Cabeceras 2–4 centradas */
-.cdb-empleado-calificacion-wrap table.cdb-grafica-scores thead th:nth-child(2),
-.cdb-empleado-calificacion-wrap table.cdb-grafica-scores thead th:nth-child(3),
-.cdb-empleado-calificacion-wrap table.cdb-grafica-scores thead th:nth-child(4){
-  text-align:center !important;
-}
-
-/* Celdas de datos 2–4 centradas */
-.cdb-empleado-calificacion-wrap table.cdb-grafica-scores tbody td:nth-child(2),
-.cdb-empleado-calificacion-wrap table.cdb-grafica-scores tbody td:nth-child(3),
-.cdb-empleado-calificacion-wrap table.cdb-grafica-scores tbody td:nth-child(4){
-    text-align:center !important;
-    vertical-align:middle;
-}
-
-/* (Opcional) Evitar cortes raros en móvil */
-@media (max-width:480px){
-    .cdb-empleado-calificacion-wrap table.cdb-grafica-scores tbody th[scope="row"]{
-      white-space:nowrap;
-      padding-right:8px;
-    }
-  }
-
-.cdb-empleado-card__score{
-  display:inline-block; margin-top:8px; padding:4px 10px;
-  border-radius:9999px; background:#111; color:#fff; font-weight:700;
-  font-variant-numeric: tabular-nums;
-}
+.cdb-empleado-calificacion-wrap{margin:24px 0}
 

--- a/inc/funciones-extra.php
+++ b/inc/funciones-extra.php
@@ -136,11 +136,8 @@ function cdb_inyectar_equipos_del_empleado_en_contenido($content) {
         return $content;
     }
 
-    $is_self = false;
-    if ( function_exists('cdb_obtener_empleado_id') ) {
-        $self_emp = (int) cdb_obtener_empleado_id( get_current_user_id() );
-        $is_self  = ($self_emp === (int) $empleado_id);
-    }
+    $is_self = function_exists('cdb_obtener_empleado_id')
+        && (int) cdb_obtener_empleado_id( get_current_user_id() ) === (int) $empleado_id;
 
     if (false === apply_filters('cdb_empleado_inyectar_grafica', true, $empleado_id)) {
         $hero_html = '';
@@ -169,22 +166,16 @@ function cdb_inyectar_equipos_del_empleado_en_contenido($content) {
     }
 
     $calificacion_block = '';
-    if ( true === apply_filters('cdb_empleado_inyectar_calificacion', true, $empleado_id) ) {
-        $args_common = array('id_suffix' => 'content', 'embed_chart' => false);
-
+    if ( true === apply_filters( 'cdb_empleado_inyectar_calificacion', true, $empleado_id ) ) {
         if ( $is_self ) {
-            // Solo lectura (misma tabla que el form)
-            $body_html = apply_filters('cdb_grafica_empleado_scores_table_html', '', $empleado_id, array('with_legend' => true));
+            $body_html = apply_filters( 'cdb_grafica_empleado_scores_table_html', '', $empleado_id, array( 'with_legend' => true ) );
         } else {
-            $can_rate = current_user_can('submit_grafica_empleado'); // capacidad actual del proyecto
-            if ( $can_rate ) {
-                $body_html = apply_filters('cdb_grafica_empleado_form_html', '', $empleado_id, $args_common);
+            if ( current_user_can( 'submit_grafica_empleado' ) ) {
+                $body_html = apply_filters( 'cdb_grafica_empleado_form_html', '', $empleado_id, array( 'id_suffix' => 'content', 'embed_chart' => false ) );
             } else {
-                // ✅ usar el aviso oficial; si algún sitio lo anula, fallback a tabla de lectura
-                $notice    = apply_filters('cdb_grafica_empleado_notice', '', $empleado_id);
-                $body_html = ! empty( $notice )
-                    ? '<div class="cdb-grafica-empleado-notice">' . $notice . '</div>'
-                    : apply_filters('cdb_grafica_empleado_scores_table_html', '', $empleado_id, array('with_legend' => true));
+                $notice    = apply_filters( 'cdb_grafica_empleado_notice', '', $empleado_id );
+                $body_html = ! empty( $notice ) ? '<div class="cdb-grafica-empleado-notice">' . $notice . '</div>'
+                    : apply_filters( 'cdb_grafica_empleado_scores_table_html', '', $empleado_id, array( 'with_legend' => true ) );
             }
         }
 


### PR DESCRIPTION
## Summary
- Compute self-check via `cdb_obtener_empleado_id` and rely on grafica filters for score table or form
- Strip legacy table styles from employee profile CSS, keeping only hero and layout rules

## Testing
- `php -l inc/funciones-extra.php`


------
https://chatgpt.com/codex/tasks/task_e_689e12a22a1883278e943e1f73ef8a8f