### PR TITLE
Use readonly accordion in employee profile

### DIFF
--- a/assets/css/perfil-empleado.css
+++ b/assets/css/perfil-empleado.css
@@ -21,3 +21,6 @@
 /* Sección inferior */
 .cdb-empleado-calificacion-wrap{margin:24px 0}
 
+/* Acordeón de lectura */
+.cdb-scores-card{background:#fff;border:1px solid #e0e0e0;border-radius:8px;padding:16px}
+

--- a/inc/funciones-extra.php
+++ b/inc/funciones-extra.php
@@ -138,6 +138,12 @@ function cdb_inyectar_equipos_del_empleado_en_contenido($content) {
 
     $is_self = function_exists('cdb_obtener_empleado_id')
         && (int) cdb_obtener_empleado_id( get_current_user_id() ) === (int) $empleado_id;
+    $comparteequipo = (bool) apply_filters(
+        'cdb_empleados_comparten_equipo',
+        false,
+        get_current_user_id(),
+        $empleado_id
+    );
 
     if (false === apply_filters('cdb_empleado_inyectar_grafica', true, $empleado_id)) {
         $hero_html = '';
@@ -167,19 +173,34 @@ function cdb_inyectar_equipos_del_empleado_en_contenido($content) {
 
     $calificacion_block = '';
     if ( true === apply_filters( 'cdb_empleado_inyectar_calificacion', true, $empleado_id ) ) {
+        $body_html = '';
+
         if ( $is_self ) {
-            $body_html = apply_filters( 'cdb_grafica_empleado_scores_table_html', '', $empleado_id, array( 'with_legend' => true ) );
+            $body_html = apply_filters(
+                'cdb_grafica_empleado_readonly_html',
+                '',
+                $empleado_id,
+                array(
+                    'id_suffix'   => 'content',
+                    'show_legend' => true,
+                )
+            );
         } else {
-            if ( current_user_can( 'submit_grafica_empleado' ) ) {
-                $body_html = apply_filters( 'cdb_grafica_empleado_form_html', '', $empleado_id, array( 'id_suffix' => 'content', 'embed_chart' => false ) );
+            if ( current_user_can( 'submit_grafica_empleado' ) && $comparteequipo ) {
+                $body_html = apply_filters(
+                    'cdb_grafica_empleado_form_html',
+                    '',
+                    $empleado_id,
+                    array( 'id_suffix' => 'content', 'embed_chart' => false )
+                );
             } else {
-                $notice    = apply_filters( 'cdb_grafica_empleado_notice', '', $empleado_id );
-                $body_html = ! empty( $notice ) ? '<div class="cdb-grafica-empleado-notice">' . $notice . '</div>'
-                    : apply_filters( 'cdb_grafica_empleado_scores_table_html', '', $empleado_id, array( 'with_legend' => true ) );
+                $body_html = apply_filters( 'cdb_grafica_empleado_notice', '', $empleado_id );
             }
         }
 
-        $calificacion_block = '<div class="cdb-empleado-calificacion-wrap">' . $body_html . '</div>';
+        if ( ! empty( $body_html ) ) {
+            $calificacion_block = '<div class="cdb-empleado-calificacion-wrap cdb-scores-card">' . $body_html . '</div>';
+        }
     }
 
     $shortcode_output = do_shortcode('[equipos_del_empleado empleado_id="' . $empleado_id . '"]');


### PR DESCRIPTION
## Summary
- Swap employee self-score table for read-only accordion
- Show score form only for teammates with `submit_grafica_empleado` capability; others see notice
- Style score card wrapper with light background and subtle border

## Testing
- `php -l inc/funciones-extra.php`
- `php -l cdb-empleado.php`


------
https://chatgpt.com/codex/tasks/task_e_689e1f01116083278c7fc7d889262957