### PR TITLE
Ensure rating notice always wrapped in HTML

### DIFF
--- a/inc/funciones-extra.php
+++ b/inc/funciones-extra.php
@@ -194,8 +194,27 @@ function cdb_inyectar_equipos_del_empleado_en_contenido($content) {
                     array( 'id_suffix' => 'content', 'embed_chart' => false )
                 );
             } else {
-                $body_html = apply_filters( 'cdb_grafica_empleado_notice', '', $empleado_id );
+                $notice_text = apply_filters(
+                    'cdb_grafica_empleado_notice',
+                    __( 'No puedes calificar a este empleado.', 'cdb-empleado' ),
+                    $empleado_id
+                );
+
+                // Siempre devolver HTML (sin huecos), preferentemente usando el helper del proveedor
+                if ( function_exists( 'cdb_grafica_notice_html' ) ) {
+                    $body_html = cdb_grafica_notice_html( $notice_text );
+                } else {
+                    // Fallback por si el helper no existiera (plugin desactivado, etc.)
+                    $body_html = '<p class="cdb-grafica-notice cdb-grafica-notice--warn">' . esc_html( $notice_text ) . '</p>';
+                }
             }
+        }
+
+        if ( '' === trim( (string) $body_html ) ) {
+            $fallback  = __( 'No se pudo generar el contenido de calificación en este momento.', 'cdb-empleado' );
+            $body_html = function_exists( 'cdb_grafica_notice_html' )
+                ? cdb_grafica_notice_html( $fallback )
+                : '<p class="cdb-grafica-notice cdb-grafica-notice--warn">' . esc_html( $fallback ) . '</p>';
         }
 
         if ( ! empty( $body_html ) ) {


### PR DESCRIPTION
## Summary
- Wrap unauthorized rating notice using `cdb_grafica_notice_html` helper
- Add fallback when notice HTML comes back empty

## Testing
- `php -l inc/funciones-extra.php`


------
https://chatgpt.com/codex/tasks/task_e_689e961acbf08327815239e43f555b95