### PR TITLE
fix(employee-content): relax content injection guards and ensure final return concatenates hero, rating block and teams

### DIFF
--- a/inc/funciones-extra.php
+++ b/inc/funciones-extra.php
@@ -132,7 +132,7 @@ add_action('init', 'cdb_equipos_del_empleado_registrar_shortcode');
 // Inyectar automáticamente la gráfica y el listado de equipos en single-empleado
 function cdb_inyectar_equipos_del_empleado_en_contenido($content) {
     $empleado_id = get_queried_object_id();
-    if (get_post_type($empleado_id) !== 'empleado' || !in_the_loop() || !is_main_query()) {
+    if ( get_post_type( $empleado_id ) !== 'empleado' ) {
         return $content;
     }
 


### PR DESCRIPTION
## Summary
- relax guards for content injection to only verify valid `empleado` post type
- ensure the injected content concatenates hero, rating block and teams shortcode

## Testing
- `php -l inc/funciones-extra.php`

------
https://chatgpt.com/codex/tasks/task_e_689f5c8ebe2c8327a6cfc23b05968119