### PR TITLE
Disable caching for employee team queries

### DIFF
--- a/cdb-empleado.php
+++ b/cdb-empleado.php
@@ -108,12 +108,15 @@ function cdb_empleado_admin_assets($hook) {
     }
 
     $equipos = get_posts(array(
-        'post_type'      => 'equipo',
-        'posts_per_page' => -1,
-        'post_status'    => 'publish',
-        'meta_key'       => '_cdb_equipo_year',
-        'orderby'        => 'meta_value_num',
-        'order'          => 'DESC',
+        'post_type'               => 'equipo',
+        'posts_per_page'          => -1,
+        'post_status'             => 'publish',
+        'meta_key'                => '_cdb_equipo_year',
+        'orderby'                 => 'meta_value_num',
+        'order'                   => 'DESC',
+        'cache_results'           => false,
+        'update_post_meta_cache'  => false,
+        'update_post_term_cache'  => false,
     ));
 
     wp_enqueue_script(
@@ -180,12 +183,15 @@ function cdb_empleado_meta_box_callback($post) {
 
     // Obtener todos los equipos disponibles
     $equipos = get_posts(array(
-        'post_type'      => 'equipo',
-        'posts_per_page' => -1,
-        'post_status'    => 'publish',
-        'meta_key'       => '_cdb_equipo_year', // Ordenar por año
-        'orderby'        => 'meta_value_num',
-        'order'          => 'DESC'
+        'post_type'               => 'equipo',
+        'posts_per_page'          => -1,
+        'post_status'             => 'publish',
+        'meta_key'                => '_cdb_equipo_year', // Ordenar por año
+        'orderby'                 => 'meta_value_num',
+        'order'                   => 'DESC',
+        'cache_results'           => false,
+        'update_post_meta_cache'  => false,
+        'update_post_term_cache'  => false,
     ));
 
     echo '<label for="cdb_empleado_year">' . __('Seleccionar Año:', 'cdb-empleado') . '</label>';

--- a/inc/funciones-extra.php
+++ b/inc/funciones-extra.php
@@ -43,13 +43,16 @@ function cdb_equipos_del_empleado_shortcode($atts) {
 
     // 2. Traer los posts del CPT "equipo"
     $equipos = get_posts(array(
-        'post_type'      => 'equipo',
-        'posts_per_page' => -1,
-        'post_status'    => 'publish',
-        'post__in'       => $equipos_ids,
-        'orderby'        => 'meta_value_num',
-        'meta_key'       => '_cdb_equipo_year',
-        'order'          => 'DESC'
+        'post_type'               => 'equipo',
+        'posts_per_page'          => -1,
+        'post_status'             => 'publish',
+        'post__in'                => $equipos_ids,
+        'orderby'                 => 'meta_value_num',
+        'meta_key'                => '_cdb_equipo_year',
+        'order'                   => 'DESC',
+        'cache_results'           => false,
+        'update_post_meta_cache'  => false,
+        'update_post_term_cache'  => false,
     ));
 
     if (empty($equipos)) {


### PR DESCRIPTION
## Summary
- disable caching for get_posts queries in employee shortcode and admin tools to ensure fresh results

## Testing
- `php -l inc/funciones-extra.php`
- `php -l cdb-empleado.php`


------
https://chatgpt.com/codex/tasks/task_e_689f772bb144832793a2d76493038688