### PR TITLE
Simplify equipo data localized to metabox script

### DIFF
--- a/assets/js/equipo-year.js
+++ b/assets/js/equipo-year.js
@@ -7,7 +7,7 @@ document.addEventListener('DOMContentLoaded', function () {
         var selectedYear = yearSelect.value;
         equipoSelect.innerHTML = '<option value="">' + cdbEmpleadoTexts.select_team + '</option>';
         equiposData.forEach(function(equipo) {
-            if (equipo.meta && equipo.meta._cdb_equipo_year == selectedYear) {
+            if (equipo._cdb_equipo_year == selectedYear) {
                 var option = document.createElement('option');
                 option.value = equipo.ID;
                 option.textContent = equipo.post_title;

--- a/cdb-empleado.php
+++ b/cdb-empleado.php
@@ -143,9 +143,7 @@ function cdb_empleado_get_equipos() {
         $equipos[] = array(
             'ID'         => $id,
             'post_title' => isset($titles[$id]) ? $titles[$id] : '',
-            'meta'       => array(
-                '_cdb_equipo_year' => isset($years[$id]) ? $years[$id] : '',
-            ),
+            '_cdb_equipo_year' => isset($years[$id]) ? $years[$id] : '',
         );
     }
 
@@ -238,7 +236,7 @@ function cdb_empleado_meta_box_callback($post) {
     // Obtener años únicos de los equipos
     $years = [];
     foreach ($equipos as $equipo) {
-        $year = $equipo['meta']['_cdb_equipo_year'];
+        $year = $equipo['_cdb_equipo_year'];
         if ($year && !in_array($year, $years)) {
             $years[] = $year;
             echo '<option value="' . esc_attr($year) . '" ' . selected($selected_year, $year, false) . '>' . esc_html($year) . '</option>';
@@ -252,7 +250,7 @@ function cdb_empleado_meta_box_callback($post) {
 
     // Mostrar equipos solo del año seleccionado
     foreach ($equipos as $equipo) {
-        $year = $equipo['meta']['_cdb_equipo_year'];
+        $year = $equipo['_cdb_equipo_year'];
         if ($selected_year == $year) {
             echo '<option value="' . esc_attr($equipo['ID']) . '" ' . selected($selected_equipo, $equipo['ID'], false) . '>' . esc_html($equipo['post_title']) . '</option>';
         }


### PR DESCRIPTION
## Summary
- Build compact equipo array with ID, title, and `_cdb_equipo_year`
- Localize the simplified array and update metabox rendering to use new keys
- Adjust `equipo-year.js` to read `_cdb_equipo_year` directly

## Testing
- `php -l cdb-empleado.php`
- `node --check assets/js/equipo-year.js`


------
https://chatgpt.com/codex/tasks/task_e_68a0d258cc7c83279cbaad7ade0e42a4