### PR TITLE
Use readonly view for self profile with fallback

### DIFF
--- a/inc/funciones-extra.php
+++ b/inc/funciones-extra.php
@@ -171,7 +171,10 @@ function cdb_inyectar_equipos_del_empleado_en_contenido($content) {
     $calificacion_block = '';
     if ( true === apply_filters( 'cdb_empleado_inyectar_calificacion', true, $empleado_id ) ) {
         if ( $is_self ) {
-            $body_html = apply_filters( 'cdb_grafica_empleado_scores_table_html', '', $empleado_id, array( 'with_legend' => true ) );
+            $body_html = apply_filters( 'cdb_grafica_empleado_readonly_html', '', $empleado_id, array( 'id_suffix' => 'content', 'show_legend' => true ) );
+            if ( '' === $body_html ) {
+                $body_html = apply_filters( 'cdb_grafica_empleado_scores_table_html', '', $empleado_id, array( 'with_legend' => true ) );
+            }
         } else {
             if ( current_user_can( 'submit_grafica_empleado' ) ) {
                 $body_html = apply_filters( 'cdb_grafica_empleado_form_html', '', $empleado_id, array( 'id_suffix' => 'content', 'embed_chart' => false ) );
@@ -182,7 +185,9 @@ function cdb_inyectar_equipos_del_empleado_en_contenido($content) {
             }
         }
 
-        $calificacion_block = '<div class="cdb-empleado-calificacion-wrap">' . $body_html . '</div>';
+        if ( ! empty( $body_html ) ) {
+            $calificacion_block = '<div class="cdb-empleado-calificacion-wrap">' . $body_html . '</div>';
+        }
     }
 
     $shortcode_output = do_shortcode('[equipos_del_empleado empleado_id="' . $empleado_id . '"]');


### PR DESCRIPTION
## Summary
- Render employee self-profile using readonly graphic HTML, falling back to scores table when unavailable
- Preserve existing form and notice behavior for other profiles, with safe wrapper only when body exists

## Testing
- `php -l inc/funciones-extra.php`


------
https://chatgpt.com/codex/tasks/task_e_68a118e7724083279e22731fd83942b2