### PR TITLE
Use readonly accordion for self ratings

### DIFF
--- a/inc/funciones-extra.php
+++ b/inc/funciones-extra.php
@@ -171,14 +171,28 @@ function cdb_inyectar_equipos_del_empleado_en_contenido($content) {
     $calificacion_block = '';
     if ( true === apply_filters( 'cdb_empleado_inyectar_calificacion', true, $empleado_id ) ) {
         if ( $is_self ) {
-            $body_html = apply_filters( 'cdb_grafica_empleado_scores_table_html', '', $empleado_id, array( 'with_legend' => true ) );
+            $body_html = apply_filters(
+                'cdb_grafica_empleado_readonly_html',
+                '',
+                $empleado_id,
+                array(
+                    'id_suffix'   => 'content',
+                    'show_legend' => true,
+                )
+            );
         } else {
             if ( current_user_can( 'submit_grafica_empleado' ) ) {
-                $body_html = apply_filters( 'cdb_grafica_empleado_form_html', '', $empleado_id, array( 'id_suffix' => 'content', 'embed_chart' => false ) );
+                $body_html = apply_filters(
+                    'cdb_grafica_empleado_form_html',
+                    '',
+                    $empleado_id,
+                    array(
+                        'id_suffix'   => 'content',
+                        'embed_chart' => false,
+                    )
+                );
             } else {
-                $notice    = apply_filters( 'cdb_grafica_empleado_notice', '', $empleado_id );
-                $body_html = ! empty( $notice ) ? '<div class="cdb-grafica-empleado-notice">' . $notice . '</div>'
-                    : apply_filters( 'cdb_grafica_empleado_scores_table_html', '', $empleado_id, array( 'with_legend' => true ) );
+                $body_html = apply_filters( 'cdb_grafica_empleado_notice', '', $empleado_id );
             }
         }
 


### PR DESCRIPTION
## Summary
- Show readonly accordion with legend when employees view their own profile
- Remove table fallback for unauthorized viewers, leaving only notice

## Testing
- `php -l inc/funciones-extra.php`
- `npm test` *(fails: package.json missing)*
- `composer test` *(fails: command not defined)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a12c0998b883279ac4083493fd975b