### PR TITLE
Add octogonal card data provider and ranking cache

### DIFF
--- a/cdb-empleado.php
+++ b/cdb-empleado.php
@@ -30,6 +30,7 @@ class Cdb_Empleado_Plugin {
         require_once plugin_dir_path( __FILE__ ) . 'inc/roles-capacidades.php';
         require_once plugin_dir_path( __FILE__ ) . 'inc/permisos.php';
         require_once plugin_dir_path( __FILE__ ) . 'inc/funciones-extra.php';
+        require_once plugin_dir_path( __FILE__ ) . 'includes/template-tags.php';
 
         add_action( 'plugins_loaded', array( $this, 'load_textdomain' ) );
         add_action( 'init', array( __CLASS__, 'registrar_cpt_empleado' ) );

--- a/inc/funciones-extra.php
+++ b/inc/funciones-extra.php
@@ -148,19 +148,25 @@ function cdb_inyectar_equipos_del_empleado_en_contenido($content) {
         $attrs        = array('id_suffix' => 'content');
         $grafica_html = apply_filters('cdb_grafica_empleado_html', '', $empleado_id, $attrs);
 
-        $empleado_author = (int) get_post_field('post_author', $empleado_id);
-        $disponible      = ('1' === get_post_meta($empleado_id, 'disponible', true));
-        $total           = (float) apply_filters('cdb_grafica_empleado_total', 0, $empleado_id);
+        if ( apply_filters( 'cdb_empleado_use_new_card', false ) ) {
+            ob_start();
+            include dirname( __DIR__ ) . '/templates/empleado-card-oct.php';
+            $card_html = ob_get_clean();
+        } else {
+            $empleado_author = (int) get_post_field('post_author', $empleado_id);
+            $disponible      = ('1' === get_post_meta($empleado_id, 'disponible', true));
+            $total           = (float) apply_filters('cdb_grafica_empleado_total', 0, $empleado_id);
 
-        $card_html  = '<div class="cdb-empleado-card">';
-        $card_html .= '<div class="cdb-empleado-card__avatar">' . get_avatar($empleado_author, 96) . '</div>';
-        $card_html .= '<div class="cdb-empleado-card__name">' . esc_html(get_the_title($empleado_id)) . '</div>';
-        $card_html .= '<div class="cdb-pill ' . ($disponible ? 'ok' : 'off') . '">';
-        $card_html .= $disponible ? __('Disponible', 'cdb-empleado') : __('No disponible', 'cdb-empleado');
-        $card_html .= '</div>';
-        $card_html .= '<div class="cdb-empleado-card__score" aria-label="Puntuación total">'
-                    .  number_format_i18n($total, 0) . '</div>';
-        $card_html .= '</div>';
+            $card_html  = '<div class="cdb-empleado-card">';
+            $card_html .= '<div class="cdb-empleado-card__avatar">' . get_avatar($empleado_author, 96) . '</div>';
+            $card_html .= '<div class="cdb-empleado-card__name">' . esc_html(get_the_title($empleado_id)) . '</div>';
+            $card_html .= '<div class="cdb-pill ' . ($disponible ? 'ok' : 'off') . '">';
+            $card_html .= $disponible ? __('Disponible', 'cdb-empleado') : __('No disponible', 'cdb-empleado');
+            $card_html .= '</div>';
+            $card_html .= '<div class="cdb-empleado-card__score" aria-label="Puntuación total">'
+                        .  number_format_i18n($total, 0) . '</div>';
+            $card_html .= '</div>';
+        }
 
         $hero_html  = '<section class="cdb-empleado-hero">';
         $hero_html .= $card_html;

--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Template tags and helpers for CdB Empleado.
+ */
+
+// Prevent direct access.
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Datos para la tarjeta octogonal.
+ *
+ * @param int $empleado_id ID del empleado.
+ *
+ * @return array
+ */
+function cdb_empleado_get_card_data( int $empleado_id ): array {
+    $name         = get_the_author_meta( 'display_name', (int) get_post_field( 'post_author', $empleado_id ) );
+    $availability = get_post_meta( $empleado_id, 'disponible', true );
+    $total        = (float) cdb_grafica_get_empleado_total( $empleado_id );
+
+    $group_avgs = (array) cdb_grafica_get_empleado_group_avgs( $empleado_id );
+    $items      = array();
+    foreach ( $group_avgs as $group => $avg ) {
+        $items[] = array(
+            'key'   => $group,
+            'value' => (float) $avg,
+        );
+    }
+
+    usort( $items, function ( $a, $b ) {
+        if ( $a['value'] === $b['value'] ) {
+            return strcmp( (string) $a['key'], (string) $b['key'] );
+        }
+        return ( $a['value'] < $b['value'] ) ? 1 : -1;
+    } );
+
+    $top_groups = array();
+    foreach ( array_slice( $items, 0, 3 ) as $item ) {
+        $top_groups[ $item['key'] ] = $item['value'];
+    }
+
+    $rank_current = cdb_empleado_get_rank_current( $empleado_id );
+
+    $data = array(
+        'name'         => $name,
+        'availability' => $availability,
+        'total'        => $total,
+        'top_groups'   => $top_groups,
+        'rank_current' => $rank_current,
+        'rank_history' => array( null, null, null ),
+        'badges'       => array(),
+    );
+
+    return apply_filters( 'cdb_empleado_card_data', $data, $empleado_id );
+}
+
+/**
+ * Ranking provisional cacheado.
+ *
+ * @param int $empleado_id ID del empleado.
+ *
+ * @return int|null Posición actual o null si no aplica.
+ */
+function cdb_empleado_get_rank_current( int $empleado_id ): ?int {
+    $map = get_transient( 'cdb_empleado_rank_map' );
+
+    if ( ! is_array( $map ) || ! isset( $map[ $empleado_id ] ) ) {
+        $ids = get_posts( array(
+            'post_type'              => 'empleado',
+            'post_status'            => 'publish',
+            'posts_per_page'         => -1,
+            'fields'                 => 'ids',
+            'no_found_rows'          => true,
+            'update_post_meta_cache' => false,
+            'update_post_term_cache' => false,
+            'cache_results'          => false,
+        ) );
+
+        $totals = array();
+        foreach ( $ids as $id ) {
+            $totals[ $id ] = (float) cdb_grafica_get_empleado_total( $id );
+        }
+
+        arsort( $totals );
+
+        $map      = array();
+        $position = 1;
+        foreach ( array_keys( $totals ) as $id ) {
+            $map[ $id ] = $position++;
+        }
+
+        $ttl = (int) apply_filters( 'cdb_empleado_rank_ttl', 600 );
+        set_transient( 'cdb_empleado_rank_map', $map, $ttl );
+    }
+
+    $rank = isset( $map[ $empleado_id ] ) ? (int) $map[ $empleado_id ] : null;
+
+    return apply_filters( 'cdb_empleado_rank_current', $rank, $empleado_id );
+}
+
+// Feature flag: nueva tarjeta desactivada por defecto.
+add_filter( 'cdb_empleado_use_new_card', '__return_false' );

--- a/templates/empleado-card-oct.php
+++ b/templates/empleado-card-oct.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Template for the octogonal employee card.
+ *
+ * @var int $empleado_id ID del empleado.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+$data = cdb_empleado_get_card_data( $empleado_id );
+?>
+<div class="cdb-empleado-card-oct">
+    <div class="cdb-empleado-card-oct__name"><?php echo esc_html( $data['name'] ); ?></div>
+    <div class="cdb-empleado-card-oct__availability">
+        <?php echo '1' === $data['availability'] ? esc_html__( 'Disponible', 'cdb-empleado' ) : esc_html__( 'No disponible', 'cdb-empleado' ); ?>
+    </div>
+    <div class="cdb-empleado-card-oct__total"><?php echo esc_html( number_format_i18n( $data['total'], 0 ) ); ?></div>
+    <?php if ( ! empty( $data['top_groups'] ) ) : ?>
+    <ul class="cdb-empleado-card-oct__top-groups">
+        <?php foreach ( $data['top_groups'] as $group => $avg ) : ?>
+            <li><?php echo esc_html( $group . ': ' . $avg ); ?></li>
+        <?php endforeach; ?>
+    </ul>
+    <?php endif; ?>
+    <?php if ( isset( $data['rank_current'] ) ) : ?>
+    <div class="cdb-empleado-card-oct__rank"><?php echo esc_html( $data['rank_current'] ); ?></div>
+    <?php endif; ?>
+    <?php if ( ! empty( $data['rank_history'] ) ) : ?>
+    <ul class="cdb-empleado-card-oct__rank-history">
+        <?php foreach ( $data['rank_history'] as $rank ) : ?>
+            <li><?php echo is_null( $rank ) ? '-' : esc_html( $rank ); ?></li>
+        <?php endforeach; ?>
+    </ul>
+    <?php endif; ?>
+    <div class="cdb-empleado-card-oct__badges">
+        <?php foreach ( $data['badges'] as $badge ) : ?>
+            <span class="cdb-empleado-card-oct__badge"><?php echo esc_html( $badge ); ?></span>
+        <?php endforeach; ?>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- add template-tags with card data provider, ranking cache and feature flag
- render new octogonal card template when feature enabled
- prepare minimal template for new card

## Testing
- `php -l includes/template-tags.php`
- `php -l templates/empleado-card-oct.php`
- `php -l inc/funciones-extra.php`
- `php -l cdb-empleado.php`


------
https://chatgpt.com/codex/tasks/task_e_68a523a99b948327aa4d17e0a53e9d96