### PR TITLE
Add octagonal employee card template and conditional styles

### DIFF
--- a/assets/css/empleado-card-oct.css
+++ b/assets/css/empleado-card-oct.css
@@ -1,0 +1,63 @@
+:root{
+  --cdb8-size: clamp(300px, 90vw, 360px);
+  --cdb8-bg:#F4EFDF; --cdb8-ink:#2B2B2B; --cdb8-border:#00000014; --cdb8-muted:#8E7E60;
+  --cdb8-pad: calc(20px * (var(--cdb8-size)/360));
+  --cdb8-gap: calc(14px * (var(--cdb8-size)/360));
+  --cdb8-avatar: calc(160px * (var(--cdb8-size)/360));
+  --cdb8-badge: calc(56px * (var(--cdb8-size)/360));
+  --cdb8-fs-name: clamp(16px, calc(var(--cdb8-size)*0.065), 28px);
+  --cdb8-fs-label: clamp(10px, calc(var(--cdb8-size)*0.035), 14px);
+  --cdb8-fs-rank: clamp(28px, calc(var(--cdb8-size)*0.18), 64px);
+}
+
+.cdb-empcard8{
+  width: min(var(--cdb8-size), 100%); aspect-ratio:1/1;
+  background:var(--cdb8-bg); color:var(--cdb8-ink);
+  border:1.5px solid var(--cdb8-border); border-radius:18px;
+  padding:var(--cdb8-pad); box-shadow:0 8px 22px rgba(0,0,0,.06);
+  display:grid; gap:var(--cdb8-gap);
+  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-rows: auto 1fr auto;
+  grid-template-areas:
+    "name   name   name"
+    "badges center rank"
+    "footer footer footer";
+  /* Octógono */
+  clip-path: polygon(10% 0, 90% 0, 100% 10%, 100% 90%, 90% 100%, 10% 100%, 0 90%, 0 10%);
+}
+
+/* Áreas */
+.cdb-empcard8__name{ grid-area:name; font-size:var(--cdb8-fs-name); font-weight:600;
+  white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.cdb-empcard8__badges{ grid-area:badges; display:grid; grid-auto-flow:column; grid-auto-columns:1fr; align-items:center; gap:calc(var(--cdb8-gap)*0.6); }
+.cdb-empcard8__badge{ width:var(--cdb8-badge); height:var(--cdb8-badge); border-radius:999px;
+  border:1px dashed var(--cdb8-border); display:grid; place-items:center; font-weight:600; color:#6b6b6b; }
+.cdb-empcard8__badge.is-empty{ opacity:.7; }
+
+.cdb-empcard8__center{ grid-area:center; display:grid; place-items:center; }
+.cdb-empcard8__center svg{ width:var(--cdb8-avatar); height:auto; color:#6B6B6B; }
+
+.cdb-empcard8__rank{ grid-area:rank; display:grid; align-content:center; justify-items:end; text-align:right; }
+.cdb-empcard8__rank-label{ font-size:var(--cdb8-fs-label); color:var(--cdb8-muted); text-transform:uppercase; letter-spacing:.06em; }
+.cdb-empcard8__rank-value{ font-size:var(--cdb8-fs-rank); line-height:1; font-weight:700; }
+
+.cdb-empcard8__footer{ grid-area:footer; display:grid; gap:calc(var(--cdb8-gap)*0.8); }
+.cdb-empcard8__section-title{ font-size:var(--cdb8-fs-label); color:var(--cdb8-muted); text-transform:uppercase; letter-spacing:.06em; }
+.cdb-empcard8__positions-list, .cdb-empcard8__groups-list{
+  display:grid; grid-template-columns:repeat(3, 1fr); gap:calc(var(--cdb8-gap)*0.5); list-style:none; padding:0; margin:0;
+}
+.cdb-empcard8__pos{ display:grid; place-items:center; min-height:2.2em; border:1px solid var(--cdb8-border);
+  border-radius:999px; font-weight:600; }
+.cdb-empcard8__grp{ display:flex; align-items:center; justify-content:center; gap:.4em; min-height:2.2em;
+  border:1px solid var(--cdb8-border); border-radius:999px; padding:0 .7em; }
+.cdb-empcard8__grp-code{ font-weight:700; }
+.cdb-empcard8__grp-val{ opacity:.9; }
+
+/* Accesibilidad */
+.screen-reader-text{ position:absolute !important; height:1px; width:1px; overflow:hidden; clip:rect(1px,1px,1px,1px); white-space:nowrap; }
+
+/* Responsivo: mantiene 3×3, solo escala */
+@media (max-width:420px){
+  :root{ --cdb8-size: clamp(280px, 96vw, 320px); }
+}
+

--- a/cdb-empleado.php
+++ b/cdb-empleado.php
@@ -323,3 +323,11 @@ register_deactivation_hook( __FILE__, array( 'Cdb_Empleado_Plugin', 'desactivar'
 // Instanciar el plugin.
 new Cdb_Empleado_Plugin();
 
+// Encolar estilos de la tarjeta octogonal solo cuando el flag esté activo.
+add_action('wp_enqueue_scripts', function(){
+  if ( apply_filters('cdb_empleado_use_new_card', false) ) {
+    wp_register_style('cdb-empleado-card-oct', plugins_url('assets/css/empleado-card-oct.css', __FILE__), [], '1.0');
+    wp_enqueue_style('cdb-empleado-card-oct');
+  }
+}, 20);
+

--- a/inc/funciones-extra.php
+++ b/inc/funciones-extra.php
@@ -150,8 +150,10 @@ function cdb_inyectar_equipos_del_empleado_en_contenido($content) {
 
         if ( apply_filters( 'cdb_empleado_use_new_card', false ) ) {
             ob_start();
-            include dirname( __DIR__ ) . '/templates/empleado-card-oct.php';
-            $card_html = ob_get_clean();
+            $empleado_id = get_the_ID();
+            include plugin_dir_path( __DIR__ ) . 'templates/empleado-card-oct.php';
+            $tarjeta_oct = ob_get_clean();
+            $card_html   = $tarjeta_oct;
         } else {
             $empleado_author = (int) get_post_field('post_author', $empleado_id);
             $disponible      = ('1' === get_post_meta($empleado_id, 'disponible', true));

--- a/templates/empleado-card-oct.php
+++ b/templates/empleado-card-oct.php
@@ -1,42 +1,87 @@
 <?php
-/**
- * Template for the octogonal employee card.
- *
- * @var int $empleado_id ID del empleado.
- */
+/** Plantilla tarjeta octogonal 3×3 */
+if ( ! function_exists('cdb_empleado_get_card_data') ) return;
 
-if ( ! defined( 'ABSPATH' ) ) {
-    exit;
-}
-
-$data = cdb_empleado_get_card_data( $empleado_id );
+$empleado_id = $empleado_id ?? get_the_ID();
+$data        = cdb_empleado_get_card_data( (int)$empleado_id );
+$name        = $data['name'] ?? '';
+$rank        = $data['rank_current'] ?? null;
+$history     = $data['rank_history'] ?? [null,null,null];
+$top_groups  = $data['top_groups'] ?? [];
+$badges      = array_slice( (array)($data['badges'] ?? []), 0, 3 );
+$card_id     = 'empcard8-'.(int)$empleado_id;
 ?>
-<div class="cdb-empleado-card-oct">
-    <div class="cdb-empleado-card-oct__name"><?php echo esc_html( $data['name'] ); ?></div>
-    <div class="cdb-empleado-card-oct__availability">
-        <?php echo '1' === $data['availability'] ? esc_html__( 'Disponible', 'cdb-empleado' ) : esc_html__( 'No disponible', 'cdb-empleado' ); ?>
+<div class="cdb-empcard8" role="group" aria-labelledby="<?php echo esc_attr($card_id); ?>" aria-describedby="<?php echo esc_attr($card_id); ?>-desc">
+  <div class="cdb-empcard8__name" id="<?php echo esc_attr($card_id); ?>" title="<?php echo esc_attr($name); ?>">
+    <?php echo esc_html( $name ); ?>
+  </div>
+
+  <div class="cdb-empcard8__badges" aria-label="<?php esc_attr_e('Insignias', 'cdb-empleado'); ?>">
+    <?php if ($badges): foreach ($badges as $b): ?>
+      <span class="cdb-empcard8__badge" title="<?php echo esc_attr($b['label'] ?? ''); ?>"></span>
+    <?php endforeach; else: ?>
+      <span class="cdb-empcard8__badge is-empty" aria-hidden="true">—</span>
+      <span class="cdb-empcard8__badge is-empty" aria-hidden="true">—</span>
+      <span class="cdb-empcard8__badge is-empty" aria-hidden="true">—</span>
+    <?php endif; ?>
+  </div>
+
+  <div class="cdb-empcard8__center" aria-hidden="true">
+    <!-- Silueta neutra SVG -->
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor" focusable="false">
+      <circle cx="128" cy="84" r="36"/><rect x="104" y="116" width="48" height="28" rx="10" ry="10"/>
+      <path d="M64 224v-16c0-33.1 28.7-60 64-60s64 26.9 64 60v16H64z"/>
+    </svg>
+  </div>
+
+  <div class="cdb-empcard8__rank">
+    <span class="cdb-empcard8__rank-label"><?php esc_html_e('Puesto', 'cdb-empleado'); ?></span>
+    <span class="cdb-empcard8__rank-value" title="<?php esc_attr_e('Puesto en el ranking total de empleados', 'cdb-empleado'); ?>">
+      <?php echo $rank ? esc_html( number_format_i18n( (int)$rank ) ) : 'ND'; ?>
+    </span>
+  </div>
+
+  <div class="cdb-empcard8__footer">
+    <div class="cdb-empcard8__positions">
+      <span class="cdb-empcard8__section-title"><?php esc_html_e('Últimas posiciones', 'cdb-empleado'); ?></span>
+      <ul class="cdb-empcard8__positions-list" aria-label="<?php esc_attr_e('Tres últimas posiciones', 'cdb-empleado'); ?>">
+        <?php for ($i=0; $i<3; $i++): ?>
+          <?php $val = $history[$i] ?? null; ?>
+          <li class="cdb-empcard8__pos"><?php echo $val ? esc_html( (int)$val ) : '—'; ?></li>
+        <?php endfor; ?>
+      </ul>
     </div>
-    <div class="cdb-empleado-card-oct__total"><?php echo esc_html( number_format_i18n( $data['total'], 0 ) ); ?></div>
-    <?php if ( ! empty( $data['top_groups'] ) ) : ?>
-    <ul class="cdb-empleado-card-oct__top-groups">
-        <?php foreach ( $data['top_groups'] as $group => $avg ) : ?>
-            <li><?php echo esc_html( $group . ': ' . $avg ); ?></li>
-        <?php endforeach; ?>
-    </ul>
-    <?php endif; ?>
-    <?php if ( isset( $data['rank_current'] ) ) : ?>
-    <div class="cdb-empleado-card-oct__rank"><?php echo esc_html( $data['rank_current'] ); ?></div>
-    <?php endif; ?>
-    <?php if ( ! empty( $data['rank_history'] ) ) : ?>
-    <ul class="cdb-empleado-card-oct__rank-history">
-        <?php foreach ( $data['rank_history'] as $rank ) : ?>
-            <li><?php echo is_null( $rank ) ? '-' : esc_html( $rank ); ?></li>
-        <?php endforeach; ?>
-    </ul>
-    <?php endif; ?>
-    <div class="cdb-empleado-card-oct__badges">
-        <?php foreach ( $data['badges'] as $badge ) : ?>
-            <span class="cdb-empleado-card-oct__badge"><?php echo esc_html( $badge ); ?></span>
-        <?php endforeach; ?>
+    <div class="cdb-empcard8__groups">
+      <span class="cdb-empcard8__section-title"><?php esc_html_e('Top grupos', 'cdb-empleado'); ?></span>
+      <ul class="cdb-empcard8__groups-list" aria-label="<?php esc_attr_e('Tres grupos con mayor promedio', 'cdb-empleado'); ?>">
+        <?php
+        $top_groups = array_slice( (array)$top_groups, 0, 3 );
+        if ( $top_groups ) :
+          foreach ( $top_groups as $g ) :
+            $k = strtoupper( (string)($g['key'] ?? '') );
+            $v = isset($g['avg']) ? round((float)$g['avg'], 1) : null;
+        ?>
+          <li class="cdb-empcard8__grp">
+            <span class="cdb-empcard8__grp-code"><?php echo esc_html($k ?: '—'); ?></span>
+            <span class="cdb-empcard8__grp-val"><?php echo is_null($v) ? '—' : esc_html( number_format_i18n($v,1) ); ?></span>
+          </li>
+        <?php
+          endforeach;
+        else :
+        ?>
+          <li class="cdb-empcard8__grp is-empty">—</li>
+          <li class="cdb-empcard8__grp is-empty">—</li>
+          <li class="cdb-empcard8__grp is-empty">—</li>
+        <?php endif; ?>
+      </ul>
     </div>
+  </div>
+
+  <span id="<?php echo esc_attr($card_id); ?>-desc" class="screen-reader-text">
+    <?php
+      $r = $rank ? sprintf( __( 'Puesto %d.', 'cdb-empleado' ), (int)$rank ) : __( 'Puesto no disponible.', 'cdb-empleado' );
+      echo esc_html( $r );
+    ?>
+  </span>
 </div>
+


### PR DESCRIPTION
## Summary
- add scalable octagonal employee card template that displays ranking, badges, history, and top groups
- add corresponding stylesheet and enqueue it conditionally via feature flag
- update content injection to load new template when cdb_empleado_use_new_card is true

## Testing
- `php -l cdb-empleado.php inc/funciones-extra.php templates/empleado-card-oct.php`


------
https://chatgpt.com/codex/tasks/task_e_68a5f42f316883279342d2f999c4e05e