### PR TITLE
Refactor top groups structure for card data

### DIFF
--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -38,7 +38,10 @@ function cdb_empleado_get_card_data( int $empleado_id ): array {
 
     $top_groups = array();
     foreach ( array_slice( $items, 0, 3 ) as $item ) {
-        $top_groups[ $item['key'] ] = $item['value'];
+        $top_groups[] = array(
+            'key' => $item['key'],
+            'avg' => (float) $item['value'],
+        );
     }
 
     $rank_current = cdb_empleado_get_rank_current( $empleado_id );


### PR DESCRIPTION
## Summary
- build `top_groups` as an array of arrays with `key` and `avg`
- verified employee card template renders group codes and averages

## Testing
- `php -l includes/template-tags.php`
- `php -l templates/empleado-card-oct.php`
- `php -r 'function cdb_empleado_get_card_data($id){return ["name"=>"Test","rank_current"=>1,"rank_history"=>[1,2,3],"top_groups"=>[["key"=>"abc","avg"=>9.5],["key"=>"def","avg"=>8.2]],"badges"=>[]];} function esc_attr($v){return $v;} function esc_attr_e($v,$d=null){echo $v;} function esc_html($v){return $v;} function esc_html_e($v,$d=null){echo $v;} function number_format_i18n($n,$d=0){return number_format($n,$d);} function get_the_ID(){return 1;} function __($s,$d=null){return $s;} include "templates/empleado-card-oct.php";'`

------
https://chatgpt.com/codex/tasks/task_e_68a602589f7483279626c070000c7999