### PR TITLE
Enable new employee card

### DIFF
--- a/cdb-empleado.php
+++ b/cdb-empleado.php
@@ -323,6 +323,9 @@ register_deactivation_hook( __FILE__, array( 'Cdb_Empleado_Plugin', 'desactivar'
 // Instanciar el plugin.
 new Cdb_Empleado_Plugin();
 
+// Forzar el uso de la nueva tarjeta de empleado.
+add_filter( 'cdb_empleado_use_new_card', '__return_true', 20 );
+
 // Encolar estilos de la tarjeta octogonal solo cuando el flag esté activo.
 add_action('wp_enqueue_scripts', function(){
   if ( apply_filters('cdb_empleado_use_new_card', false) ) {


### PR DESCRIPTION
## Summary
- activate new employee card by forcing `cdb_empleado_use_new_card` filter to return true

## Testing
- `php -l cdb-empleado.php`

------
https://chatgpt.com/codex/tasks/task_e_68a603638c508327ab2b4df7ed41e4a8