### PR TITLE
Use external silhouette image

### DIFF
--- a/assets/css/empleado-card-oct.css
+++ b/assets/css/empleado-card-oct.css
@@ -38,7 +38,7 @@
 .cdb-empcard8__badge.is-empty{ opacity:.7; }
 
 .cdb-empcard8__center{ grid-area:center; display:grid; place-items:center; }
-.cdb-empcard8__center svg{ width:var(--cdb8-avatar); height:auto; color:#6B6B6B; }
+.cdb-empcard8__center img{ width:var(--cdb8-avatar); height:auto; }
 
 .cdb-empcard8__rank{ grid-area:rank; display:grid; align-content:center; justify-items:end; text-align:right; }
 .cdb-empcard8__rank-label{ font-size:var(--cdb8-fs-label); color:var(--cdb8-muted); text-transform:uppercase; letter-spacing:.06em; }

--- a/assets/img/empleado-silueta.svg
+++ b/assets/img/empleado-silueta.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="#6B6B6B">
+  <circle cx="128" cy="84" r="36"/>
+  <rect x="104" y="116" width="48" height="28" rx="10" ry="10"/>
+  <path d="M64 224v-16c0-33.1 28.7-60 64-60s64 26.9 64 60v16H64z"/>
+</svg>

--- a/templates/empleado-card-oct.php
+++ b/templates/empleado-card-oct.php
@@ -27,11 +27,7 @@ $card_id     = 'empcard8-'.(int)$empleado_id;
   </div>
 
   <div class="cdb-empcard8__center" aria-hidden="true">
-    <!-- Silueta neutra SVG -->
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor" focusable="false">
-      <circle cx="128" cy="84" r="36"/><rect x="104" y="116" width="48" height="28" rx="10" ry="10"/>
-      <path d="M64 224v-16c0-33.1 28.7-60 64-60s64 26.9 64 60v16H64z"/>
-    </svg>
+    <img src="<?php echo esc_url( plugins_url('assets/img/empleado-silueta.svg', __FILE__) ); ?>" alt="" />
   </div>
 
   <div class="cdb-empcard8__rank">


### PR DESCRIPTION
## Summary
- add reusable employee silhouette SVG asset
- replace inline SVG in `empleado-card-oct.php` with `<img>` tag
- adjust CSS so `.cdb-empcard8__center` continues to size the image correctly

## Testing
- `php -l templates/empleado-card-oct.php`


------
https://chatgpt.com/codex/tasks/task_e_68a608cf55bc83279418c7e165bef454