### PR TITLE
refactor: simplify CSS scaling for employee card

### DIFF
--- a/assets/css/empleado-card-oct.css
+++ b/assets/css/empleado-card-oct.css
@@ -1,10 +1,10 @@
 :root{
   --card-size: clamp(300px, 90vw, 360px);
   --cdb8-bg:#F4EFDF; --cdb8-ink:#2B2B2B; --cdb8-border:#00000014; --cdb8-muted:#8E7E60;
-  --cdb8-pad: calc(20px * (var(--card-size)/360));
-  --cdb8-gap: calc(14px * (var(--card-size)/360));
-  --cdb8-avatar: calc(160px * (var(--card-size)/360));
-  --cdb8-badge: calc(56px * (var(--card-size)/360));
+  --cdb8-pad:   calc(var(--card-size) * 20 / 360);
+  --cdb8-gap:   calc(var(--card-size) * 14 / 360);
+  --cdb8-avatar:calc(var(--card-size) * 160 / 360);
+  --cdb8-badge: calc(var(--card-size) * 56 / 360);
   --cdb8-fs-name: clamp(16px, calc(var(--card-size)*0.065), 28px);
   --cdb8-fs-label: clamp(10px, calc(var(--card-size)*0.035), 14px);
   --cdb8-fs-rank: clamp(28px, calc(var(--card-size)*0.18), 64px);


### PR DESCRIPTION
## Summary
- remove px multiplications in employee card CSS, replacing with normalized calc expressions

## Testing
- `node -e "[300,360,420].forEach(s=>{console.log('size',s,'=> pad',s*20/360,'gap',s*14/360,'avatar',s*160/360,'badge',s*56/360);})"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a65d7192cc8327bd6e22dc2cd25c7a