### PR TITLE
Add labeled badge wrapper for oct card

### DIFF
--- a/assets/css/empleado-card-oct.css
+++ b/assets/css/empleado-card-oct.css
@@ -37,9 +37,11 @@
 /* Áreas */
 .cdb-empcard8__name{ grid-area:name; font-size:var(--cdb8-fs-name); font-weight:600; text-align:center; text-transform:uppercase;
   white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
-.cdb-empcard8__badges{ grid-area:badges; display:grid; grid-auto-flow:column; grid-auto-columns:1fr; align-items:center; gap:calc(var(--cdb8-gap)*0.6); }
-.cdb-empcard8__badge{ width:var(--cdb8-badge); height:var(--cdb8-badge); border-radius:999px;
-  border:1px solid var(--cdb8-border); display:grid; place-items:center; font-weight:600; color:#6b6b6b; }
+.cdb-empcard8__badges-wrap{ grid-area:badges; display:grid; gap:calc(var(--cdb8-gap)*0.4); }
+.cdb-empcard8__badges-label{ font-size:var(--cdb8-fs-label); color:var(--cdb8-muted); text-transform:uppercase; letter-spacing:.06em; }
+.cdb-empcard8__badges{ display:grid; grid-auto-flow:column; grid-auto-columns:1fr; align-items:center; gap:calc(var(--cdb8-gap)*0.6); }
+.cdb-empcard8__badge{ width:var(--cdb8-badge); height:var(--cdb8-badge); border-radius:999px; border:1px solid var(--cdb8-border);
+  display:grid; place-items:center; font-weight:600; color:#6b6b6b; }
 .cdb-empcard8__badge.is-empty{ color:var(--cdb8-muted); opacity:.6; }
 
 .cdb-empcard8__center{ grid-area:center; display:grid; place-items:center; }

--- a/templates/empleado-card-oct.php
+++ b/templates/empleado-card-oct.php
@@ -16,14 +16,17 @@ $card_id     = 'empcard8-'.(int)$empleado_id;
     <?php echo esc_html( $name ); ?>
   </div>
 
-  <div class="cdb-empcard8__badges" aria-label="<?php esc_attr_e('Insignias', 'cdb-empleado'); ?>">
-    <?php if ($badges): foreach ($badges as $b): ?>
-      <span class="cdb-empcard8__badge" title="<?php echo esc_attr($b['label'] ?? ''); ?>"></span>
-    <?php endforeach; else: ?>
-      <span class="cdb-empcard8__badge is-empty" aria-hidden="true">—</span>
-      <span class="cdb-empcard8__badge is-empty" aria-hidden="true">—</span>
-      <span class="cdb-empcard8__badge is-empty" aria-hidden="true">—</span>
-    <?php endif; ?>
+  <div class="cdb-empcard8__badges-wrap">
+    <span class="cdb-empcard8__badges-label"><?php esc_html_e('Insignias','cdb-empleado'); ?></span>
+    <div class="cdb-empcard8__badges">
+      <?php if ($badges): foreach ($badges as $b): ?>
+        <span class="cdb-empcard8__badge" title="<?php echo esc_attr($b['label'] ?? ''); ?>"></span>
+      <?php endforeach; else: ?>
+        <span class="cdb-empcard8__badge is-empty" aria-hidden="true">—</span>
+        <span class="cdb-empcard8__badge is-empty" aria-hidden="true">—</span>
+        <span class="cdb-empcard8__badge is-empty" aria-hidden="true">—</span>
+      <?php endif; ?>
+    </div>
   </div>
 
   <div class="cdb-empcard8__center" aria-hidden="true">


### PR DESCRIPTION
## Summary
- wrap badges section with label in employee card template
- style badges wrapper and label for vertical layout and use variable border

## Testing
- `php -l templates/empleado-card-oct.php`
- `npm test` *(fails: ENOENT package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a666fd4d688327b10ceef06b16e7fe