### PR TITLE
Show last positions as comma-separated text

### DIFF
--- a/assets/css/empleado-card-oct.css
+++ b/assets/css/empleado-card-oct.css
@@ -53,11 +53,10 @@
 
 .cdb-empcard8__footer{ grid-area:footer; display:grid; gap:calc(var(--cdb8-gap)*0.8); }
 .cdb-empcard8__section-title{ font-size:var(--cdb8-fs-label); color:var(--cdb8-muted); text-transform:uppercase; letter-spacing:.06em; }
-.cdb-empcard8__positions-list, .cdb-empcard8__groups-list{
+.cdb-empcard8__groups-list{
   display:grid; grid-template-columns:repeat(3, 1fr); gap:calc(var(--cdb8-gap)*0.5); list-style:none; padding:0; margin:0;
 }
-.cdb-empcard8__pos{ display:grid; place-items:center; min-height:2.2em; border:1px solid var(--cdb8-border);
-  border-radius:999px; font-weight:600; }
+.cdb-empcard8__positions-values{ font-size:var(--cdb8-fs-label); }
 .cdb-empcard8__grp{ display:flex; align-items:center; justify-content:center; gap:.4em; min-height:2.2em;
   border:1px solid var(--cdb8-border); border-radius:999px; padding:0 .7em; }
 .cdb-empcard8__grp.is-empty{ color:var(--cdb8-muted); opacity:.6; }

--- a/templates/empleado-card-oct.php
+++ b/templates/empleado-card-oct.php
@@ -47,12 +47,12 @@ $card_id     = 'empcard8-'.(int)$empleado_id;
   <div class="cdb-empcard8__footer">
     <div class="cdb-empcard8__positions">
       <span class="cdb-empcard8__section-title"><?php esc_html_e('Últimas posiciones', 'cdb-empleado'); ?></span>
-      <ul class="cdb-empcard8__positions-list" aria-label="<?php esc_attr_e('Tres últimas posiciones', 'cdb-empleado'); ?>">
-        <?php for ($i=0; $i<3; $i++): ?>
-          <?php $val = $history[$i] ?? null; ?>
-          <li class="cdb-empcard8__pos"><?php echo $val ? esc_html( (int)$val ) : '—'; ?></li>
-        <?php endfor; ?>
-      </ul>
+      <?php
+        $positions = array_slice($history, 0, 3);
+        $text = implode(', ', array_map(
+          fn($v) => $v ? (int)$v : '—', $positions));
+      ?>
+      <p class="cdb-empcard8__positions-values"><?php echo esc_html($text); ?></p>
     </div>
     <div class="cdb-empcard8__groups">
       <span class="cdb-empcard8__section-title"><?php esc_html_e('Top grupos', 'cdb-empleado'); ?></span>


### PR DESCRIPTION
## Summary
- Simplify "Últimas posiciones" display to a comma-separated string
- Add styling for the new positions text and drop unused list styles

## Testing
- `php -l templates/empleado-card-oct.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a66883e61c8327bc423e3849b7d2c5