### PR TITLE
Use grid layout for top groups in octagonal card

### DIFF
--- a/assets/css/empleado-card-oct.css
+++ b/assets/css/empleado-card-oct.css
@@ -53,13 +53,12 @@
 
 .cdb-empcard8__footer{ grid-area:footer; display:grid; gap:calc(var(--cdb8-gap)*0.8); }
 .cdb-empcard8__section-title{ font-size:var(--cdb8-fs-label); color:var(--cdb8-muted); text-transform:uppercase; letter-spacing:.06em; }
-.cdb-empcard8__groups-list{
-  display:grid; grid-template-columns:repeat(3, 1fr); gap:calc(var(--cdb8-gap)*0.5); list-style:none; padding:0; margin:0;
-}
+.cdb-empcard8__groups-table{ display:grid; grid-template-columns:repeat(3,1fr); }
 .cdb-empcard8__positions-values{ font-size:var(--cdb8-fs-label); }
-.cdb-empcard8__grp{ display:flex; align-items:center; justify-content:center; gap:.4em; min-height:2.2em;
-  border:1px solid var(--cdb8-border); border-radius:999px; padding:0 .7em; }
-.cdb-empcard8__grp.is-empty{ color:var(--cdb8-muted); opacity:.6; }
+.cdb-empcard8__grp{ display:flex; flex-direction:column; align-items:center; }
+.cdb-empcard8__grp:first-child{ border-right:1px solid var(--cdb8-border); }
+.cdb-empcard8__grp:nth-child(2){ border-left:1px solid var(--cdb8-border); border-right:1px solid var(--cdb8-border); }
+.cdb-empcard8__grp:last-child{ border-left:1px solid var(--cdb8-border); }
 .cdb-empcard8__grp-code{ font-weight:700; }
 .cdb-empcard8__grp-val{ opacity:.9; }
 

--- a/templates/empleado-card-oct.php
+++ b/templates/empleado-card-oct.php
@@ -56,27 +56,17 @@ $card_id     = 'empcard8-'.(int)$empleado_id;
     </div>
     <div class="cdb-empcard8__groups">
       <span class="cdb-empcard8__section-title"><?php esc_html_e('Top grupos', 'cdb-empleado'); ?></span>
-      <ul class="cdb-empcard8__groups-list" aria-label="<?php esc_attr_e('Tres grupos con mayor promedio', 'cdb-empleado'); ?>">
-        <?php
-        $top_groups = array_slice( (array)$top_groups, 0, 3 );
-        if ( $top_groups ) :
-          foreach ( $top_groups as $g ) :
-            $k = strtoupper( (string)($g['key'] ?? '') );
-            $v = isset($g['avg']) ? round((float)$g['avg'], 1) : null;
-        ?>
-          <li class="cdb-empcard8__grp">
-            <span class="cdb-empcard8__grp-code"><?php echo esc_html($k ?: '—'); ?></span>
-            <span class="cdb-empcard8__grp-val"><?php echo is_null($v) ? '—' : esc_html( number_format_i18n($v,1) ); ?></span>
-          </li>
-        <?php
-          endforeach;
-        else :
-        ?>
-          <li class="cdb-empcard8__grp is-empty">—</li>
-          <li class="cdb-empcard8__grp is-empty">—</li>
-          <li class="cdb-empcard8__grp is-empty">—</li>
-        <?php endif; ?>
-      </ul>
+      <?php $top_groups = array_slice( (array) $top_groups, 0, 3 ); ?>
+      <div class="cdb-empcard8__groups-table">
+        <?php foreach ( $top_groups as $g ):
+          $k = strtoupper( (string) ( $g['key'] ?? '' ) );
+          $v = isset( $g['avg'] ) ? round( (float) $g['avg'], 1 ) : null; ?>
+          <div class="cdb-empcard8__grp">
+            <span class="cdb-empcard8__grp-code"><?php echo esc_html( $k ?: '—' ); ?></span>
+            <span class="cdb-empcard8__grp-val"><?php echo is_null( $v ) ? '—' : esc_html( number_format_i18n( $v, 1 ) ); ?></span>
+          </div>
+        <?php endforeach; ?>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- Replace pill list with div grid for "Top grupos" in employee card
- Style new group grid and column borders

## Testing
- `php -l templates/empleado-card-oct.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a669d9b524832797044b643b161614