### PR TITLE
Refactor card sizing variables

### DIFF
--- a/assets/css/empleado-card-oct.css
+++ b/assets/css/empleado-card-oct.css
@@ -1,10 +1,11 @@
 :root{
   --card-size: clamp(300px, 90vw, 360px);
+  --cdb8-size: var(--card-size);
   --cdb8-bg:#F4EFDF; --cdb8-ink:#2B2B2B; --cdb8-border:#00000014; --cdb8-muted:#8E7E60;
-  --cdb8-pad:   calc(var(--card-size) * 20 / 360);
-  --cdb8-gap:   calc(var(--card-size) * 14 / 360);
-  --cdb8-avatar:calc(var(--card-size) * 160 / 360);
-  --cdb8-badge: calc(var(--card-size) * 56 / 360);
+  --cdb8-pad:   calc(var(--cdb8-size) * 20 / 360);
+  --cdb8-gap:   calc(var(--cdb8-size) * 14 / 360);
+  --cdb8-avatar:calc(var(--cdb8-size) * 160 / 360);
+  --cdb8-badge: calc(var(--cdb8-size) * 56 / 360);
   --cdb8-fs-name: clamp(16px, calc(var(--card-size)*0.065), 28px);
   --cdb8-fs-label: clamp(10px, calc(var(--card-size)*0.035), 14px);
   --cdb8-fs-rank: clamp(28px, calc(var(--card-size)*0.18), 64px);


### PR DESCRIPTION
## Summary
- use `--cdb8-size` for padding, gaps, avatar and badge dimensions in `empleado-card-oct`
- alias `--cdb8-size` to `--card-size` for consistent scaling

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node -e "const sizes=[280,300,360,420]; for(const s of sizes){ const pad=s*20/360; const gap=s*14/360; const avatar=s*160/360; const badge=s*56/360; console.log('size',s,'=> pad',pad.toFixed(2),'gap',gap.toFixed(2),'avatar',avatar.toFixed(2),'badge',badge.toFixed(2)); }"`


------
https://chatgpt.com/codex/tasks/task_e_68a66b3ad4348327b9d39d55f69eb8d0