### PR TITLE
refactor: scale card variables with card-size

### DIFF
--- a/assets/css/empleado-card-oct.css
+++ b/assets/css/empleado-card-oct.css
@@ -1,11 +1,10 @@
 :root{
   --card-size: clamp(300px, 90vw, 360px);
-  --cdb8-size: var(--card-size);
   --cdb8-bg:#F4EFDF; --cdb8-ink:#2B2B2B; --cdb8-border:#00000014; --cdb8-muted:#8E7E60;
-  --cdb8-pad:   calc(var(--cdb8-size) * 20 / 360);
-  --cdb8-gap:   calc(var(--cdb8-size) * 14 / 360);
-  --cdb8-avatar:calc(var(--cdb8-size) * 160 / 360);
-  --cdb8-badge: calc(var(--cdb8-size) * 56 / 360);
+  --cdb8-pad:   calc(var(--card-size) * 20 / 360);
+  --cdb8-gap:   calc(var(--card-size) * 14 / 360);
+  --cdb8-avatar:calc(var(--card-size) * 160 / 360);
+  --cdb8-badge: calc(var(--card-size) * 56 / 360);
   --cdb8-fs-name: clamp(16px, calc(var(--card-size)*0.065), 28px);
   --cdb8-fs-label: clamp(10px, calc(var(--card-size)*0.035), 14px);
   --cdb8-fs-rank: clamp(28px, calc(var(--card-size)*0.18), 64px);


### PR DESCRIPTION
## Summary
- derive padding, gaps, avatar, and badge dimensions from `--card-size` ratios for consistent scaling

## Testing
- `npm test` *(fails: ENOENT, no such file package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a66eea9a288327868b9e224b0dee11