### PR TITLE
style: refine badges layout

### DIFF
--- a/assets/css/empleado-card-oct.css
+++ b/assets/css/empleado-card-oct.css
@@ -37,8 +37,8 @@
 /* Áreas */
 .cdb-empcard8__name{ grid-area:name; font-size:var(--cdb8-fs-name); font-weight:600; text-align:center; text-transform:uppercase;
   white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
-.cdb-empcard8__badges-wrap{ grid-area:badges; display:grid; gap:calc(var(--cdb8-gap)*0.4); }
-.cdb-empcard8__badges-label{ font-size:var(--cdb8-fs-label); color:var(--cdb8-muted); text-transform:uppercase; letter-spacing:.06em; }
+.cdb-empcard8__badges-wrap{ grid-area:badges; display:grid; gap:calc(var(--cdb8-gap)*0.4); align-content:start; }
+.cdb-empcard8__badges-label{ display:block; font-size:var(--cdb8-fs-label); color:var(--cdb8-muted); text-transform:uppercase; letter-spacing:.06em; }
 .cdb-empcard8__badges{ display:grid; grid-auto-flow:column; grid-auto-columns:1fr; align-items:center; gap:calc(var(--cdb8-gap)*0.6); }
 .cdb-empcard8__badge{ width:var(--cdb8-badge); height:var(--cdb8-badge); border-radius:999px; border:1px solid var(--cdb8-border);
   display:grid; place-items:center; font-weight:600; color:#6b6b6b; }

--- a/templates/empleado-card-oct.php
+++ b/templates/empleado-card-oct.php
@@ -17,7 +17,7 @@ $card_id     = 'empcard8-'.(int)$empleado_id;
   </div>
 
   <div class="cdb-empcard8__badges-wrap">
-    <span class="cdb-empcard8__badges-label"><?php esc_html_e('Insignias','cdb-empleado'); ?></span>
+    <span class="cdb-empcard8__badges-label"><?php esc_html_e( 'Insignias', 'cdb-empleado' ); ?></span>
     <div class="cdb-empcard8__badges">
       <?php if ($badges): foreach ($badges as $b): ?>
         <span class="cdb-empcard8__badge" title="<?php echo esc_attr($b['label'] ?? ''); ?>"></span>


### PR DESCRIPTION
## Summary
- polish translation spacing for badges label
- improve badge wrapper layout and make label block-level

## Testing
- `php -l templates/empleado-card-oct.php`


------
https://chatgpt.com/codex/tasks/task_e_68a67343e4cc83278fd7536523e0af4b