### PR TITLE
feat: ajustar tarjeta octogonal de empleado

### DIFF
--- a/assets/css/empleado-card-oct.css
+++ b/assets/css/empleado-card-oct.css
@@ -1,72 +1,76 @@
 :root{
-  --card-size: clamp(300px, 90vw, 360px);
-  --cdb8-bg:#F4EFDF; --cdb8-ink:#2B2B2B; --cdb8-border:#00000014; --cdb8-muted:#8E7E60;
-  --cdb8-pad:   calc(var(--card-size) * 20 / 360);
-  --cdb8-gap:   calc(var(--card-size) * 14 / 360);
-  --cdb8-avatar:calc(var(--card-size) * 160 / 360);
-  --cdb8-badge: calc(var(--card-size) * 56 / 360);
-  --cdb8-fs-name: clamp(16px, calc(var(--card-size)*0.065), 28px);
-  --cdb8-fs-label: clamp(10px, calc(var(--card-size)*0.035), 14px);
-  --cdb8-fs-rank: clamp(28px, calc(var(--card-size)*0.18), 64px);
+  --cdb8-size: clamp(300px, 90vw, 360px);
+  --cdb8-bg:#F4EFDF; --cdb8-ink:#2B2B2B; --cdb8-border:#00000018; --cdb8-muted:#8E7E60;
+  --cdb8-pad: calc(20px * (var(--cdb8-size)/360));
+  --cdb8-gap: calc(14px * (var(--cdb8-size)/360));
+  --cdb8-avatar: calc(160px * (var(--cdb8-size)/360));
+  --cdb8-badge: calc(56px * (var(--cdb8-size)/360));
+  --cdb8-fs-name: clamp(16px, calc(var(--cdb8-size)*0.065), 28px);
+  --cdb8-fs-label: clamp(10px, calc(var(--cdb8-size)*0.035), 14px);
+  --cdb8-fs-rank: clamp(28px, calc(var(--cdb8-size)*0.18), 64px);
+  /* factor del octógono regular ≈ 1 - 1/sqrt(2) */
+  --k: 29.29%;
 }
 
 .cdb-empcard8{
-  width: min(var(--card-size), 100%); aspect-ratio:1/1;
+  width:min(var(--cdb8-size),100%); aspect-ratio:1/1;
   background:var(--cdb8-bg); color:var(--cdb8-ink);
-  border:1.5px solid var(--cdb8-border);
+  border:1.5px solid var(--cdb8-border); border-radius:18px;
   padding:var(--cdb8-pad); box-shadow:0 8px 22px rgba(0,0,0,.06);
   display:grid; gap:var(--cdb8-gap);
-  grid-template-columns: 1fr 1fr 1fr;
-  grid-template-rows: auto 1fr auto;
+  grid-template-columns:1fr 1fr 1fr;
+  grid-template-rows:auto 1fr auto;
   grid-template-areas:
     "name   name   name"
     "badges center rank"
     "footer footer footer";
-  /* Octógono */
-  clip-path: polygon(
-    10% 0, 90% 0,
-    100% 10%, 100% 90%,
-    90% 100%, 10% 100%,
-    0 90%, 0 10%
-  );
+  /* Octógono regular: 8 lados iguales */
+  clip-path:polygon(var(--k) 0, calc(100% - var(--k)) 0, 100% var(--k),
+                    100% calc(100% - var(--k)), calc(100% - var(--k)) 100%,
+                    var(--k) 100%, 0 calc(100% - var(--k)), 0 var(--k));
 }
 
-.cdb-empcard8--s{ --card-size:300px; }
-.cdb-empcard8--l{ --card-size:420px; }
+/* NAME (centrado, mayúsculas) */
+.cdb-empcard8__name{
+  grid-area:name; text-align:center; text-transform:uppercase;
+  letter-spacing:.06em; font-weight:700; font-size:var(--cdb8-fs-name);
+  white-space:nowrap; overflow:hidden; text-overflow:ellipsis;
+}
 
-/* Áreas */
-.cdb-empcard8__name{ grid-area:name; font-size:var(--cdb8-fs-name); font-weight:600; text-align:center; text-transform:uppercase;
-  white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
-.cdb-empcard8__badges-wrap{ grid-area:badges; display:grid; gap:calc(var(--cdb8-gap)*0.4); align-content:start; }
-.cdb-empcard8__badges-label{ display:block; font-size:var(--cdb8-fs-label); color:var(--cdb8-muted); text-transform:uppercase; letter-spacing:.06em; }
-.cdb-empcard8__badges{ display:grid; grid-auto-flow:column; grid-auto-columns:1fr; align-items:center; gap:calc(var(--cdb8-gap)*0.6); }
-.cdb-empcard8__badge{ width:var(--cdb8-badge); height:var(--cdb8-badge); border-radius:999px; border:1px solid var(--cdb8-border);
-  display:grid; place-items:center; font-weight:600; color:#6b6b6b; }
-.cdb-empcard8__badge.is-empty{ color:var(--cdb8-muted); opacity:.6; }
+/* BADGES */
+.cdb-empcard8__badges{ grid-area:badges; display:grid; align-content:start; gap:calc(var(--cdb8-gap)*0.6); }
+.cdb-empcard8__badges-title{ font-size:var(--cdb8-fs-label); color:var(--cdb8-muted); text-transform:uppercase; letter-spacing:.06em; }
+.cdb-empcard8__badges-list{ display:grid; grid-auto-flow:column; gap:calc(var(--cdb8-gap)*0.6); }
+.cdb-empcard8__badge{ width:var(--cdb8-badge); height:var(--cdb8-badge); border-radius:999px;
+  border:1px dashed var(--cdb8-border); display:grid; place-items:center; color:#6b6b6b; font-weight:600; }
+.cdb-empcard8__badge.is-empty{ opacity:.7; }
 
+/* SILUETA */
 .cdb-empcard8__center{ grid-area:center; display:grid; place-items:center; }
-.cdb-empcard8__center img{ width:var(--cdb8-avatar); height:auto; }
+.cdb-empcard8__center svg{ width:var(--cdb8-avatar); height:auto; color:#6B6B6B; }
 
+/* RANK (PUESTO) */
 .cdb-empcard8__rank{ grid-area:rank; display:grid; align-content:center; justify-items:end; text-align:right; }
 .cdb-empcard8__rank-label{ font-size:var(--cdb8-fs-label); color:var(--cdb8-muted); text-transform:uppercase; letter-spacing:.06em; }
-.cdb-empcard8__rank-value{ font-size:var(--cdb8-fs-rank); line-height:1; font-weight:700; }
+.cdb-empcard8__rank-value{ font-size:var(--cdb8-fs-rank); line-height:1; font-weight:800; white-space:nowrap; }
 
+/* FOOTER */
 .cdb-empcard8__footer{ grid-area:footer; display:grid; gap:calc(var(--cdb8-gap)*0.8); }
 .cdb-empcard8__section-title{ font-size:var(--cdb8-fs-label); color:var(--cdb8-muted); text-transform:uppercase; letter-spacing:.06em; }
-.cdb-empcard8__groups-table{ display:grid; grid-template-columns:repeat(3,1fr); }
-.cdb-empcard8__positions-values{ font-size:var(--cdb8-fs-label); }
-.cdb-empcard8__grp{ display:flex; flex-direction:column; align-items:center; }
-.cdb-empcard8__grp:first-child{ border-right:1px solid var(--cdb8-border); }
-.cdb-empcard8__grp:nth-child(2){ border-left:1px solid var(--cdb8-border); border-right:1px solid var(--cdb8-border); }
-.cdb-empcard8__grp:last-child{ border-left:1px solid var(--cdb8-border); }
+
+/* Posiciones en una sola línea */
+.cdb-empcard8__positions-line{ font-size:var(--cdb8-fs-label); opacity:.9; }
+
+/* Top grupos: 3 celdas */
+.cdb-empcard8__groups-list{ display:grid; grid-template-columns:repeat(3, 1fr); gap:calc(var(--cdb8-gap)*0.5); list-style:none; padding:0; margin:0; }
+.cdb-empcard8__grp{ display:grid; grid-template-rows:auto auto; align-items:center; justify-items:center;
+  min-height:2.6em; border:1px solid var(--cdb8-border); border-radius:999px; padding:.3em .7em; }
 .cdb-empcard8__grp-code{ font-weight:700; }
 .cdb-empcard8__grp-val{ opacity:.9; }
 
-/* Accesibilidad */
+/* A11y helper */
 .screen-reader-text{ position:absolute !important; height:1px; width:1px; overflow:hidden; clip:rect(1px,1px,1px,1px); white-space:nowrap; }
 
-/* Responsivo: mantiene 3×3, solo escala */
 @media (max-width:420px){
-  :root{ --card-size: clamp(280px, 96vw, 320px); }
+  :root{ --cdb8-size: clamp(280px, 96vw, 320px); }
 }
-

--- a/templates/empleado-card-oct.php
+++ b/templates/empleado-card-oct.php
@@ -1,80 +1,88 @@
 <?php
-/** Plantilla tarjeta octogonal 3×3 */
+/** Tarjeta octogonal 3×3 conforme a la referencia */
 if ( ! function_exists('cdb_empleado_get_card_data') ) return;
 
 $empleado_id = $empleado_id ?? get_the_ID();
 $data        = cdb_empleado_get_card_data( (int)$empleado_id );
 $name        = $data['name'] ?? '';
 $rank        = $data['rank_current'] ?? null;
-$history     = $data['rank_history'] ?? [null,null,null];
-$top_groups  = $data['top_groups'] ?? [];
+$history     = (array)($data['rank_history'] ?? [null,null,null]);
+$top_groups  = array_slice( (array)($data['top_groups'] ?? []), 0, 3 );
 $badges      = array_slice( (array)($data['badges'] ?? []), 0, 3 );
-$card_id     = 'empcard8-'.(int)$empleado_id;
+
+$positions_text = implode(', ', array_map(
+  static function($v){ return $v ? (string)(int)$v : '—'; },
+  array_slice($history, 0, 3)
+));
+
+$card_id = 'empcard8-'.(int)$empleado_id;
 ?>
 <div class="cdb-empcard8" role="group" aria-labelledby="<?php echo esc_attr($card_id); ?>" aria-describedby="<?php echo esc_attr($card_id); ?>-desc">
+  <!-- NAME -->
   <div class="cdb-empcard8__name" id="<?php echo esc_attr($card_id); ?>" title="<?php echo esc_attr($name); ?>">
-    <?php echo esc_html( $name ); ?>
+    <?php echo esc_html( mb_strtoupper($name) ); ?>
   </div>
 
-  <div class="cdb-empcard8__badges-wrap">
-    <span class="cdb-empcard8__badges-label"><?php esc_html_e( 'Insignias', 'cdb-empleado' ); ?></span>
-    <div class="cdb-empcard8__badges">
+  <!-- BADGES -->
+  <div class="cdb-empcard8__badges">
+    <div class="cdb-empcard8__badges-title"><?php esc_html_e('Insignias', 'cdb-empleado'); ?></div>
+    <div class="cdb-empcard8__badges-list" aria-label="<?php esc_attr_e('Insignias', 'cdb-empleado'); ?>">
       <?php if ($badges): foreach ($badges as $b): ?>
         <span class="cdb-empcard8__badge" title="<?php echo esc_attr($b['label'] ?? ''); ?>"></span>
       <?php endforeach; else: ?>
-        <span class="cdb-empcard8__badge is-empty" aria-hidden="true">—</span>
-        <span class="cdb-empcard8__badge is-empty" aria-hidden="true">—</span>
-        <span class="cdb-empcard8__badge is-empty" aria-hidden="true">—</span>
+        <span class="cdb-empcard8__badge is-empty">—</span>
+        <span class="cdb-empcard8__badge is-empty">—</span>
+        <span class="cdb-empcard8__badge is-empty">—</span>
       <?php endif; ?>
     </div>
   </div>
 
+  <!-- SILUETA -->
   <div class="cdb-empcard8__center" aria-hidden="true">
-    <img src="<?php echo esc_url( plugins_url( 'assets/img/empleado-silueta.svg', __FILE__ ) ); ?>" alt="" />
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor" focusable="false">
+      <circle cx="128" cy="84" r="36"/><rect x="104" y="116" width="48" height="28" rx="10" ry="10"/>
+      <path d="M64 224v-16c0-33.1 28.7-60 64-60s64 26.9 64 60v16H64z"/>
+    </svg>
   </div>
 
+  <!-- RANK -->
   <div class="cdb-empcard8__rank">
     <span class="cdb-empcard8__rank-label"><?php esc_html_e('Puesto', 'cdb-empleado'); ?></span>
-    <?php
-      $title = $rank ? __( 'Puesto en el ranking total de empleados', 'cdb-empleado' )
-                     : __( 'Aún sin ranking', 'cdb-empleado' );
-    ?>
-    <span class="cdb-empcard8__rank-value" title="<?php echo esc_attr( $title ); ?>">
-      <?php echo $rank ? sprintf( '%02d', (int) $rank ) : 'ND'; ?>
+    <span class="cdb-empcard8__rank-value" title="<?php esc_attr_e('Puesto en el ranking total de empleados', 'cdb-empleado'); ?>">
+      <?php echo $rank ? esc_html( number_format_i18n( (int)$rank ) ) : 'ND'; ?>
     </span>
   </div>
 
+  <!-- FOOTER -->
   <div class="cdb-empcard8__footer">
-    <div class="cdb-empcard8__positions">
+    <div>
       <span class="cdb-empcard8__section-title"><?php esc_html_e('Últimas posiciones', 'cdb-empleado'); ?></span>
-      <?php
-        $positions = array_slice($history, 0, 3);
-        $text = implode(', ', array_map(
-          fn($v) => $v ? (int)$v : '—', $positions));
-      ?>
-      <p class="cdb-empcard8__positions-values"><?php echo esc_html($text); ?></p>
+      <div class="cdb-empcard8__positions-line"><?php echo esc_html( $positions_text ); ?></div>
     </div>
-    <div class="cdb-empcard8__groups">
+
+    <div>
       <span class="cdb-empcard8__section-title"><?php esc_html_e('Top grupos', 'cdb-empleado'); ?></span>
-      <?php $top_groups = array_slice( (array) $top_groups, 0, 3 ); ?>
-      <div class="cdb-empcard8__groups-table">
-        <?php foreach ( $top_groups as $g ):
-          $k = strtoupper( (string) ( $g['key'] ?? '' ) );
-          $v = isset( $g['avg'] ) ? round( (float) $g['avg'], 1 ) : null; ?>
-          <div class="cdb-empcard8__grp">
-            <span class="cdb-empcard8__grp-code"><?php echo esc_html( $k ?: '—' ); ?></span>
-            <span class="cdb-empcard8__grp-val"><?php echo is_null( $v ) ? '—' : esc_html( number_format_i18n( $v, 1 ) ); ?></span>
-          </div>
-        <?php endforeach; ?>
-      </div>
+      <ul class="cdb-empcard8__groups-list" aria-label="<?php esc_attr_e('Tres grupos con mayor promedio', 'cdb-empleado'); ?>">
+        <?php if ($top_groups): foreach ($top_groups as $g):
+          $k = strtoupper( (string)($g['key'] ?? '') );
+          $v = isset($g['avg']) ? round((float)$g['avg'], 1) : null; ?>
+          <li class="cdb-empcard8__grp">
+            <span class="cdb-empcard8__grp-code"><?php echo esc_html($k ?: '—'); ?></span>
+            <span class="cdb-empcard8__grp-val"><?php echo is_null($v) ? '—' : esc_html( number_format_i18n($v,1) ); ?></span>
+          </li>
+        <?php endforeach; else: ?>
+          <li class="cdb-empcard8__grp">—</li>
+          <li class="cdb-empcard8__grp">—</li>
+          <li class="cdb-empcard8__grp">—</li>
+        <?php endif; ?>
+      </ul>
     </div>
   </div>
 
   <span id="<?php echo esc_attr($card_id); ?>-desc" class="screen-reader-text">
     <?php
       $r = $rank ? sprintf( __( 'Puesto %d.', 'cdb-empleado' ), (int)$rank ) : __( 'Puesto no disponible.', 'cdb-empleado' );
-      echo esc_html( $r );
+      echo esc_html( $r . ' ' . __( 'Top grupos mostrados.', 'cdb-empleado' ) );
     ?>
   </span>
 </div>
-


### PR DESCRIPTION
## Summary
- remodelar estilos de `empleado-card-oct` para octógono regular y layout 3×3
- actualizar plantilla PHP con nombre en mayúsculas, silueta SVG y grupos/promedios

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a676a7a450832797e761ab938f71fb