### PR TITLE
feat: support separate table filter for employee chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Este plugin asume que existen los CPT `equipo` y `cdb_posiciones`, así como la 
 ## Hooks relevantes
 
 - `cdb_empleado_inyectar_grafica` y `cdb_empleado_inyectar_calificacion` permiten habilitar o deshabilitar los bloques automáticos.
-- `cdb_grafica_empleado_html`, `cdb_grafica_empleado_form_html`, `cdb_grafica_empleado_scores_table_html` y `cdb_grafica_empleado_total` se utilizan para personalizar la información mostrada en la tarjeta y la gráfica.
+- `cdb_grafica_empleado_html`, `cdb_grafica_empleado_form_html`, `cdb_grafica_empleado_scores_table_html` y `cdb_grafica_empleado_total` se utilizan para personalizar la información mostrada en la tarjeta y la gráfica. El filtro `cdb_grafica_empleado_html` debe devolver únicamente el marcado del gráfico; si se requiere una tabla de puntuaciones se puede usar `cdb_grafica_empleado_scores_table_html`.
 
 ## Changelog
 

--- a/inc/funciones-extra.php
+++ b/inc/funciones-extra.php
@@ -147,7 +147,6 @@ function cdb_inyectar_equipos_del_empleado_en_contenido($content) {
     } else {
         $attrs        = array('id_suffix' => 'content');
         $grafica_html = apply_filters('cdb_grafica_empleado_html', '', $empleado_id, $attrs);
-        $grafica_tiene_tabla = ( false !== strpos( $grafica_html, '<table' ) );
 
         if ( apply_filters( 'cdb_empleado_use_new_card', false ) ) {
             ob_start();
@@ -180,20 +179,16 @@ function cdb_inyectar_equipos_del_empleado_en_contenido($content) {
     $calificacion_block = '';
     if ( true === apply_filters( 'cdb_empleado_inyectar_calificacion', true, $empleado_id ) ) {
         if ( $is_self ) {
-            $body_html = $grafica_tiene_tabla
-                ? ''
-                : apply_filters( 'cdb_grafica_empleado_scores_table_html', '', $empleado_id, array( 'with_legend' => true ) );
+            $body_html = apply_filters( 'cdb_grafica_empleado_scores_table_html', '', $empleado_id, array( 'with_legend' => true ) );
         } else {
             if ( current_user_can( 'submit_grafica_empleado' ) ) {
                 $body_html = apply_filters( 'cdb_grafica_empleado_form_html', '', $empleado_id, array( 'id_suffix' => 'content', 'embed_chart' => false ) );
             } else {
-                $notice    = apply_filters( 'cdb_grafica_empleado_notice', '', $empleado_id );
+                $notice = apply_filters( 'cdb_grafica_empleado_notice', '', $empleado_id );
                 if ( ! empty( $notice ) ) {
                     $body_html = '<div class="cdb-grafica-empleado-notice">' . $notice . '</div>';
-                } elseif ( ! $grafica_tiene_tabla ) {
-                    $body_html = apply_filters( 'cdb_grafica_empleado_scores_table_html', '', $empleado_id, array( 'with_legend' => true ) );
                 } else {
-                    $body_html = '';
+                    $body_html = apply_filters( 'cdb_grafica_empleado_scores_table_html', '', $empleado_id, array( 'with_legend' => true ) );
                 }
             }
         }


### PR DESCRIPTION
## Summary
- ensure `cdb_grafica_empleado_html` returns only chart markup
- load rating table through `cdb_grafica_empleado_scores_table_html`
- document chart/table hook usage

## Testing
- `php -l inc/funciones-extra.php`


------
https://chatgpt.com/codex/tasks/task_e_68a6eaf02ad08327bd79642aa5e4ce98