### PR TITLE
docs: add audit report and overhaul README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,142 @@
 # CdB Empleado
 
-Plugin de WordPress que añade el tipo de contenido **Empleado** y las herramientas necesarias para describir su disponibilidad y experiencia dentro de la plataforma CdB.
+Plugin de WordPress que registra el tipo de contenido **Empleado**, su rol asociado y las herramientas para gestionar **disponibilidad, equipos y calificaciones** dentro de la plataforma CdB. En la vista singular del empleado se **auto-inyecta** una tarjeta de perfil con **gráfica** y **listado de equipos**.
 
-## Características
+## Tabla de contenidos
+- [Descripción](#descripción)
+- [Requisitos](#requisitos)
+- [Dependencias y supuestos](#dependencias-y-supuestos)
+- [Instalación](#instalación)
+- [Configuración](#configuración)
+- [Uso](#uso)
+- [Shortcodes](#shortcodes)
+- [Hooks y filtros](#hooks-y-filtros)
+- [Modelo de datos](#modelo-de-datos)
+- [Assets (CSS/JS)](#assets-cssjs)
+- [Seguridad e i18n](#seguridad-e-i18n)
+- [Compatibilidad y buenas prácticas](#compatibilidad-y-buenas-prácticas)
+- [Solución de problemas](#solución-de-problemas)
+- [Roadmap](#roadmap)
+- [Licencia y créditos](#licencia-y-créditos)
+- [Changelog](#changelog)
 
-- Registro del CPT `empleado` con soporte para editor, imagen destacada y API REST.
-- Metacampo "Disponible" para indicar si el empleado está activo.
-- Metabox **Equipo y Año** que relaciona cada empleado con un CPT `equipo`; las opciones de equipo se filtran dinámicamente según el año seleccionado.
-- Rol personalizado `empleado` con capacidades mínimas de lectura.
-- Inyección automática en la vista individual de Empleado de una tarjeta con información, una gráfica de puntuación (a través de filtros) y el listado de equipos.
-- Shortcode `[equipos_del_empleado empleado_id="123"]` que muestra los equipos y posiciones del empleado a partir de la tabla `cdb_experiencia`.
-- Estilos específicos para el perfil del empleado en `assets/css/perfil-empleado.css`.
+## Descripción
+- CPT `empleado` con `show_in_rest` habilitado (título, editor, imagen destacada, autor, campos personalizados).
+- Rol `empleado` con capacidades mínimas de lectura.
+- Metacampo **Disponible** y metabox **Equipo y Año** (filtrado dinámico por año).
+- Auto-inyección en `single` de empleado: **tarjeta**, **gráfica de calificación** y **listado de equipos**.
+
+## Requisitos
+- **Mínimos:** WordPress 4.7+, PHP 7.1+  
+- **Recomendado:** WordPress 6.6+, PHP 8.1+
+
+## Dependencias y supuestos
+- CPT `equipo` (meta `_cdb_equipo_year`)
+- CPT `cdb_posiciones` (meta `_cdb_posiciones_score`)
+- Tabla personalizada **`${prefix}cdb_experiencia`** (`empleado_id`, `equipo_id`, `posicion_id`)
+- Plugin **cdb-grafica** para cálculos/representación de la gráfica
 
 ## Instalación
+### Desde ZIP
+1. Comprime como `cdb-empleado.zip`.
+2. *Plugins → Añadir nuevo → Subir plugin*.
+3. Activa **CdB Empleado**.
 
-1. Copia la carpeta del plugin en `wp-content/plugins`.
-2. Activa **CdB Empleado** desde el panel de administración de WordPress.
+### Desde repositorio
+1. Clona en `wp-content/plugins/cdb-empleado`.
+2. Activa en el panel de administración.
 
-Este plugin asume que existen los CPT `equipo` y `cdb_posiciones`, así como la tabla personalizada `cdb_experiencia` donde se registra la participación del empleado en cada equipo.
+## Configuración
+### Metacampo “Disponible”
+- Metabox **Información del Empleado**  
+- Meta key: `disponible` (`1`/`0`)
+
+### Metabox “Equipo y Año”
+- Filtrado dinámico de equipos por año (`assets/js/equipo-year.js`)  
+- Meta keys: `_cdb_empleado_year`, `_cdb_empleado_equipo`
+
+### Auto-inyección en `single` de empleado
+Inserta **tarjeta + gráfica + bloque de calificación + listado de equipos**.  
+Para desactivar:
+```php
+add_filter('cdb_empleado_inyectar_grafica', '__return_false');
+add_filter('cdb_empleado_inyectar_calificacion', '__return_false');
+```
 
 ## Uso
+### Shortcode principal
+```html
+[equipos_del_empleado]
+[equipos_del_empleado empleado_id="123"]
+```
+- Si no se indica `empleado_id`, usa el ID del post actual.
+- La salida lista equipos y posiciones según `${prefix}cdb_experiencia`.
 
-1. Crea una entrada del tipo **Empleado**.
-2. Completa el metacampo **Disponible** y asigna un **Equipo** y **Año** en la metabox lateral.
-3. Inserta el shortcode `[equipos_del_empleado]` (o `[equipos_del_empleado empleado_id="ID"]`) en cualquier contenido para mostrar los equipos en los que ha participado.
-4. En la plantilla singular de empleado el plugin inyecta automáticamente una tarjeta con la gráfica, un bloque de calificación y el listado de equipos.
+### Hooks habituales
+```php
+add_filter('cdb_grafica_empleado_html', function($html, $empleado_id, $args){
+    return '<div class="mi-grafica">...</div>';
+}, 10, 3);
+```
 
-## Hooks relevantes
+## Shortcodes
+| Shortcode | Atributos | Descripción | Ejemplo |
+|-----------|-----------|-------------|---------|
+| `equipos_del_empleado` | `empleado_id` (int, opcional; por defecto el post ID) | Lista equipos y posiciones del empleado consultando `${prefix}cdb_experiencia`. | `[equipos_del_empleado empleado_id="15"]` |
 
-- `cdb_empleado_inyectar_grafica` y `cdb_empleado_inyectar_calificacion` permiten habilitar o deshabilitar los bloques automáticos.
-- `cdb_grafica_empleado_html`, `cdb_grafica_empleado_form_html`, `cdb_grafica_empleado_scores_table_html` y `cdb_grafica_empleado_total` se utilizan para personalizar la información mostrada en la tarjeta y la gráfica.
+## Hooks y filtros
+| Hook/filtro | Propósito | Parámetros | Retorno | Ejemplo |
+|-------------|-----------|------------|---------|---------|
+| `cdb_empleado_inyectar_grafica` | Habilita/inhibe la gráfica en `single` de empleado. | `bool $enabled`, `int $empleado_id` | bool | `add_filter('cdb_empleado_inyectar_grafica','__return_false');` |
+| `cdb_empleado_inyectar_calificacion` | Controla el bloque de calificación. | `bool $enabled`, `int $empleado_id` | bool | `add_filter('cdb_empleado_inyectar_calificacion','__return_false');` |
+| `cdb_grafica_empleado_html` | Sustituye el HTML de la gráfica. | `string $html`, `int $empleado_id`, `array $args` | string | `add_filter('cdb_grafica_empleado_html','mi_callback',10,3);` |
+| `cdb_grafica_empleado_form_html` | Personaliza el formulario de calificación. | `string $html`, `int $empleado_id`, `array $args` | string | `add_filter('cdb_grafica_empleado_form_html','mi_form',10,3);` |
+| `cdb_grafica_empleado_scores_table_html` | Ajusta la tabla de puntuaciones. | `string $html`, `int $empleado_id`, `array $args` | string | `add_filter('cdb_grafica_empleado_scores_table_html','mi_tabla',10,3);` |
+| `cdb_grafica_empleado_total` | Modifica el puntaje total mostrado. | `float $total`, `int $empleado_id` | float | `add_filter('cdb_grafica_empleado_total','mi_total',10,2);` |
+| `cdb_empleado_use_new_card` | Decide uso de tarjeta alternativa. | `bool $use_new`, `int $empleado_id` | bool | `add_filter('cdb_empleado_use_new_card','__return_true');` |
+| `cdb_grafica_empleado_notice` | Personaliza aviso en la sección de calificación. | `string $msg`, `int $empleado_id` | string | `add_filter('cdb_grafica_empleado_notice','mi_aviso',10,2);` |
+| `cdb_empleado_card_data` | Filtra datos mostrados en la tarjeta. | `array $data`, `int $empleado_id` | array | `add_filter('cdb_empleado_card_data','mi_data',10,2);` |
+| `cdb_empleado_rank_ttl` | Ajusta duración del caché de rankings. | `int $seconds` | int | `add_filter('cdb_empleado_rank_ttl', fn()=>300);` |
+| `cdb_empleado_rank_current` | Modifica ranking calculado para un empleado. | `mixed $rank`, `int $empleado_id` | mixed | `add_filter('cdb_empleado_rank_current','mi_rank',10,2);` |
+
+## Modelo de datos
+- **CPTs:** `empleado` (propio), `equipo`, `cdb_posiciones` (supuestos)  
+- **Rol:** `empleado` (capacidad `read`)  
+- **Meta keys:** `disponible`, `_cdb_empleado_year`, `_cdb_empleado_equipo`  
+- **Tabla:** `${prefix}cdb_experiencia` (relación empleado–equipo–posición)
+
+## Assets (CSS/JS)
+| Handle | Tipo | Dónde se carga | Notas |
+|--------|------|----------------|-------|
+| `cdb-empleado-metabox` | JS | Admin al **editar/crear** CPT empleado | `cdb-empleado.php:168-179` |
+| `cdb-perfil-empleado` | CSS | Solo en `is_singular('empleado')` | `cdb-empleado.php:199-204` |
+| `cdb-empleado-card-oct` | CSS | Tarjeta alternativa si `cdb_empleado_use_new_card` → `true` | `cdb-empleado.php:327-330` |
+
+## Seguridad e i18n
+- **Nonces:**  
+  - `cdb_empleado_nonce` → `inc/metacampos-empleado.php:31` (verificación en `:48`)  
+  - `cdb_empleado_equipo_nonce` → `cdb-empleado.php:227` (verificación en `:262-263`)  
+- **Capacidades:** `edit_post` al guardar metaboxes  
+- **Textdomain:** `cdb-empleado`
+
+## Compatibilidad y buenas prácticas
+- Encola assets **solo donde se usan**.  
+- Usa `${prefix}` (`$wpdb->prefix`) al consultar tablas personalizadas.  
+- Evita cache en la página singular de empleado con `nocache_headers`.
+
+## Solución de problemas
+- **No se muestran equipos:** comprueba registros en `${prefix}cdb_experiencia` y existencia de CPTs requeridos.  
+- **No aparece la gráfica:** verifica que **cdb-grafica** esté activo y que no se haya deshabilitado `cdb_empleado_inyectar_grafica`.
+
+## Roadmap
+- Endpoints REST específicos para consultas de experiencia.  
+- Soporte para tarjetas/insignias adicionales.
+
+## Licencia y créditos
+- Licencia: GPL-2.0  
+- Autor: Proyecto CdB — https://proyectocdb.es
 
 ## Changelog
-
 ### 1.0.2
 - Se corrigió el paso de datos de equipos a JavaScript para que se envíen como un array nativo en lugar de una cadena JSON.
 
@@ -41,4 +145,3 @@ Este plugin asume que existen los CPT `equipo` y `cdb_posiciones`, así como la 
 
 ### 1.0.0
 - Versión inicial.
-

--- a/docs/readme-informe.md
+++ b/docs/readme-informe.md
@@ -1,0 +1,76 @@
+# Informe de auditoría – CdB Empleado
+
+## 1) Mapa del plugin
+```
+cdb-empleado/
+├── cdb-empleado.php
+├── assets/
+│   ├── css/
+│   │   ├── empleado-card-oct.css
+│   │   └── perfil-empleado.css
+│   └── js/
+│       └── equipo-year.js
+├── inc/
+│   ├── funciones-extra.php
+│   ├── metacampos-empleado.php
+│   ├── permisos.php
+│   └── roles-capacidades.php
+├── includes/
+│   └── template-tags.php
+├── templates/
+│   └── empleado-card-oct.php
+└── README.md
+```
+
+## 2) Hechos verificados
+- **CPTs**
+  - `empleado` (`show_in_rest` verdadero, soporta título, editor, imagen destacada, autor y campos personalizados).
+- **Roles y capacidades**
+  - Rol `empleado` con capacidad `read`.
+- **Metaboxes / Metacampo**
+  - “Información del Empleado” → meta key `disponible`.
+  - “Equipo y Año” → meta keys `_cdb_empleado_equipo`, `_cdb_empleado_year` (filtro dinámico por año).
+- **Shortcodes**
+  - `[equipos_del_empleado]` (`empleado_id` opcional; por defecto usa el ID del post actual).
+- **Hooks / filtros**
+  - `cdb_empleado_inyectar_grafica`, `cdb_empleado_inyectar_calificacion`.
+  - `cdb_grafica_empleado_html`, `cdb_grafica_empleado_form_html`, `cdb_grafica_empleado_scores_table_html`, `cdb_grafica_empleado_total`.
+  - `cdb_empleado_use_new_card`, `cdb_grafica_empleado_notice`, `cdb_empleado_card_data`, `cdb_empleado_rank_ttl`, `cdb_empleado_rank_current`.
+- **Endpoints AJAX/REST**
+  - No se registran endpoints propios; el CPT `empleado` expone sus datos vía REST de WordPress.
+- **Tablas personalizadas**
+  - `${$wpdb->prefix}cdb_experiencia` (campos usados: `empleado_id`, `equipo_id`, `posicion_id`).
+
+## 3) Dependencias y supuestos
+- Existencia previa de:
+  - CPT `equipo` con meta `_cdb_equipo_year`.
+  - CPT `cdb_posiciones` con meta `_cdb_posiciones_score`.
+  - Tabla `${$wpdb->prefix}cdb_experiencia` para relacionar empleado–equipo–posición.
+- Integración con el plugin **cdb-grafica** (provee funciones/filters de la gráfica).
+- Auto‑inyección en `single` de empleado: tarjeta + gráfica + bloque de calificación + listado de equipos.
+- Assets registrados:
+  - JS admin `cdb-empleado-metabox`.
+  - CSS frontal `cdb-perfil-empleado`.
+  - CSS opcional `cdb-empleado-card-oct` (activado por `cdb_empleado_use_new_card`).
+
+## 4) Brechas del README actual
+- Falta de secciones: requisitos, dependencias, configuración, uso detallado, tablas de shortcodes y hooks, modelo de datos, assets, seguridad/i18n, compatibilidad, troubleshooting, roadmap, licencia.
+- No incluye tabla de contenidos ni ejemplos prácticos de hooks/shortcodes.
+- Nomenclatura parcial (p.ej., metacampo “Disponible” sin referencia al meta key).
+- No documenta la auto‑inyección ni cómo desactivarla.
+- No se mencionan los handles de assets ni el textdomain.
+
+## 5) Checklist para README.md
+- [ ] Añadir descripción breve y propósito.
+- [ ] Especificar requisitos mínimos (WP/PHP).
+- [ ] Detallar dependencias: CPT `equipo`, `cdb_posiciones`, tabla `${prefix}cdb_experiencia`, plugin `cdb-grafica`.
+- [ ] Incluir instrucciones de instalación desde ZIP y repositorio.
+- [ ] Documentar configuración: metacampo “Disponible”, metabox “Equipo y Año”, auto‑inyección y desactivación vía filtros.
+- [ ] Proporcionar ejemplos de uso del shortcode `[equipos_del_empleado]`.
+- [ ] Crear tabla de shortcodes.
+- [ ] Crear tabla de hooks/filtros con parámetros, retorno y ejemplos.
+- [ ] Describir modelo de datos (CPTs, roles, meta keys, tabla personalizada).
+- [ ] Enumerar assets con handles y condiciones de carga.
+- [ ] Explicar medidas de seguridad (nonces, capabilities) y i18n (textdomain).
+- [ ] Añadir secciones de compatibilidad, troubleshooting, roadmap, licencia y créditos.
+- [ ] Mantener el Changelog existente sin modificaciones.


### PR DESCRIPTION
## Summary
- add audit report with plugin map, verified features, and README gaps
- expand README with installation, configuration, shortcodes, hooks, assets, and security info

## Testing
- `find . -name "*.php" -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68a748d4f4c483279275269672a4c913