### PR TITLE
feat: replace employee card with octagonal layout

### DIFF
--- a/assets/css/empleado-card-oct.css
+++ b/assets/css/empleado-card-oct.css
@@ -1,63 +1,22 @@
 :root{
-  --cdb8-size: clamp(300px, 90vw, 360px);
-  --cdb8-bg:#F4EFDF; --cdb8-ink:#2B2B2B; --cdb8-border:#00000014; --cdb8-muted:#8E7E60;
-  --cdb8-pad: calc(20px * (var(--cdb8-size)/360));
-  --cdb8-gap: calc(14px * (var(--cdb8-size)/360));
-  --cdb8-avatar: calc(160px * (var(--cdb8-size)/360));
-  --cdb8-badge: calc(56px * (var(--cdb8-size)/360));
-  --cdb8-fs-name: clamp(16px, calc(var(--cdb8-size)*0.065), 28px);
-  --cdb8-fs-label: clamp(10px, calc(var(--cdb8-size)*0.035), 14px);
-  --cdb8-fs-rank: clamp(28px, calc(var(--cdb8-size)*0.18), 64px);
+  --cdb-ink:#4a453c; --cdb-ink-2:#6a6459; --cdb-paper:#f3eedf;
+  --cdb-shadow:0 1px 0 rgba(0,0,0,.04),0 6px 18px rgba(0,0,0,.06);
+  --pad:clamp(10px,2.2vw,24px); --name-size:clamp(18px,2.4vw,26px);
+  --avatar-max:clamp(110px,36%,180px); --rank-label:clamp(8px,.9vw,10px);
+  --rank-num:clamp(18px,3.1vw,32px); --row-gap:clamp(6px,1.4vw,16px);
 }
-
-.cdb-empcard8{
-  width: min(var(--cdb8-size), 100%); aspect-ratio:1/1;
-  background:var(--cdb8-bg); color:var(--cdb8-ink);
-  border:1.5px solid var(--cdb8-border); border-radius:18px;
-  padding:var(--cdb8-pad); box-shadow:0 8px 22px rgba(0,0,0,.06);
-  display:grid; gap:var(--cdb8-gap);
-  grid-template-columns: 1fr 1fr 1fr;
-  grid-template-rows: auto 1fr auto;
-  grid-template-areas:
-    "name   name   name"
-    "badges center rank"
-    "footer footer footer";
-  /* Octógono */
-  clip-path: polygon(10% 0, 90% 0, 100% 10%, 100% 90%, 90% 100%, 10% 100%, 0 90%, 0 10%);
+.cdb-card-oct{
+  --cut:29.2893%;
+  width:min(92vw,560px); aspect-ratio:1/1;
+  clip-path:polygon(var(--cut) 0%,calc(100% - var(--cut)) 0%,100% var(--cut),100% calc(100% - var(--cut)),
+                   calc(100% - var(--cut)) 100%,var(--cut) 100%,0% calc(100% - var(--cut)),0% var(--cut));
+  background:var(--cdb-paper); border:1.5px solid var(--cdb-ink-2); box-shadow:var(--cdb-shadow); color:var(--cdb-ink);
+  display:grid; place-items:stretch; font-family:ui-sans-serif,system-ui,-apple-system,"Helvetica Neue",Arial;
 }
-
-/* Áreas */
-.cdb-empcard8__name{ grid-area:name; font-size:var(--cdb8-fs-name); font-weight:600;
-  white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
-.cdb-empcard8__badges{ grid-area:badges; display:grid; grid-auto-flow:column; grid-auto-columns:1fr; align-items:center; gap:calc(var(--cdb8-gap)*0.6); }
-.cdb-empcard8__badge{ width:var(--cdb8-badge); height:var(--cdb8-badge); border-radius:999px;
-  border:1px dashed var(--cdb8-border); display:grid; place-items:center; font-weight:600; color:#6b6b6b; }
-.cdb-empcard8__badge.is-empty{ opacity:.7; }
-
-.cdb-empcard8__center{ grid-area:center; display:grid; place-items:center; }
-.cdb-empcard8__center svg{ width:var(--cdb8-avatar); height:auto; color:#6B6B6B; }
-
-.cdb-empcard8__rank{ grid-area:rank; display:grid; align-content:center; justify-items:end; text-align:right; }
-.cdb-empcard8__rank-label{ font-size:var(--cdb8-fs-label); color:var(--cdb8-muted); text-transform:uppercase; letter-spacing:.06em; }
-.cdb-empcard8__rank-value{ font-size:var(--cdb8-fs-rank); line-height:1; font-weight:700; }
-
-.cdb-empcard8__footer{ grid-area:footer; display:grid; gap:calc(var(--cdb8-gap)*0.8); }
-.cdb-empcard8__section-title{ font-size:var(--cdb8-fs-label); color:var(--cdb8-muted); text-transform:uppercase; letter-spacing:.06em; }
-.cdb-empcard8__positions-list, .cdb-empcard8__groups-list{
-  display:grid; grid-template-columns:repeat(3, 1fr); gap:calc(var(--cdb8-gap)*0.5); list-style:none; padding:0; margin:0;
-}
-.cdb-empcard8__pos{ display:grid; place-items:center; min-height:2.2em; border:1px solid var(--cdb8-border);
-  border-radius:999px; font-weight:600; }
-.cdb-empcard8__grp{ display:flex; align-items:center; justify-content:center; gap:.4em; min-height:2.2em;
-  border:1px solid var(--cdb8-border); border-radius:999px; padding:0 .7em; }
-.cdb-empcard8__grp-code{ font-weight:700; }
-.cdb-empcard8__grp-val{ opacity:.9; }
-
-/* Accesibilidad */
-.screen-reader-text{ position:absolute !important; height:1px; width:1px; overflow:hidden; clip:rect(1px,1px,1px,1px); white-space:nowrap; }
-
-/* Responsivo: mantiene 3×3, solo escala */
-@media (max-width:420px){
-  :root{ --cdb8-size: clamp(280px, 96vw, 320px); }
-}
-
+.cdb-card-oct__inner{ display:grid; grid-template-columns:repeat(3,1fr); grid-template-rows:.9fr 1.2fr .9fr; gap:var(--row-gap); padding:var(--pad); }
+.cdb-card-oct__name{ grid-column:2/3; grid-row:1/2; place-self:center; margin:0; font-size:var(--name-size); font-weight:700; letter-spacing:.06em; text-transform:uppercase; text-align:center; }
+.cdb-card-oct__avatar{ grid-column:2/3; grid-row:2/3; place-self:center; }
+.cdb-card-oct__svg{ display:block; width:var(--avatar-max); height:auto; fill:#6f6a60; }
+.cdb-card-oct__rank{ grid-column:3/4; grid-row:2/3; align-self:center; justify-self:end; display:flex; flex-direction:column; align-items:center; gap:2px; text-align:center; transform:translateY(-4%); }
+.cdb-card-oct__rank-label{ font-size:var(--rank-label); letter-spacing:.14em; text-transform:uppercase; opacity:.72; }
+.cdb-card-oct__rank-num{ font-size:var(--rank-num); line-height:1; font-weight:700; letter-spacing:.02em; border:1px solid var(--cdb-ink-2); padding:.18em .36em; border-radius:8px; background:#f6f2e6; }

--- a/cdb-empleado.php
+++ b/cdb-empleado.php
@@ -16,6 +16,15 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit; // Evita el acceso directo al archivo
 }
 
+if ( ! defined( 'CDB_EMPLEADO_PLUGIN_DIR' ) ) {
+    define( 'CDB_EMPLEADO_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+}
+if ( ! defined( 'CDB_EMPLEADO_PLUGIN_URL' ) ) {
+    define( 'CDB_EMPLEADO_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+}
+
+require_once CDB_EMPLEADO_PLUGIN_DIR . 'inc/card-oct-helpers.php';
+
 /**
  * Clase principal del plugin CdB Empleado.
  */
@@ -31,6 +40,7 @@ class Cdb_Empleado_Plugin {
         require_once plugin_dir_path( __FILE__ ) . 'inc/permisos.php';
         require_once plugin_dir_path( __FILE__ ) . 'inc/funciones-extra.php';
         require_once plugin_dir_path( __FILE__ ) . 'includes/template-tags.php';
+        require_once plugin_dir_path( __FILE__ ) . 'includes/shortcodes.php';
 
         add_action( 'plugins_loaded', array( $this, 'load_textdomain' ) );
         add_action( 'init', array( __CLASS__, 'registrar_cpt_empleado' ) );
@@ -323,11 +333,24 @@ register_deactivation_hook( __FILE__, array( 'Cdb_Empleado_Plugin', 'desactivar'
 // Instanciar el plugin.
 new Cdb_Empleado_Plugin();
 
-// Encolar estilos de la tarjeta octogonal solo cuando el flag esté activo.
-add_action('wp_enqueue_scripts', function(){
-  if ( apply_filters('cdb_empleado_use_new_card', false) ) {
-    wp_register_style('cdb-empleado-card-oct', plugins_url('assets/css/empleado-card-oct.css', __FILE__), [], '1.0');
-    wp_enqueue_style('cdb-empleado-card-oct');
-  }
-}, 20);
+// Fuerza el uso de la nueva tarjeta en el CPT empleado.
+add_filter( 'cdb_empleado_use_new_card', '__return_true', 99 );
+
+add_action( 'wp_enqueue_scripts', function () {
+    $use_new = apply_filters( 'cdb_empleado_use_new_card', false );
+
+    if ( $use_new ) {
+        // Desactiva estilos antiguos de la tarjeta clásica
+        wp_dequeue_style( 'cdb-perfil-empleado' );
+        wp_deregister_style( 'cdb-perfil-empleado' );
+
+        // Estilos de la tarjeta octogonal
+        wp_enqueue_style(
+            'cdb-empleado-card-oct',
+            CDB_EMPLEADO_PLUGIN_URL . 'assets/css/empleado-card-oct.css',
+            [],
+            '1.0.0'
+        );
+    }
+}, 20 );
 

--- a/inc/card-oct-helpers.php
+++ b/inc/card-oct-helpers.php
@@ -1,0 +1,47 @@
+<?php
+// Obtener ID del CPT 'empleado' de un autor (utilidad general)
+function cdb_empleado_get_post_by_author( $user_id ){
+    $posts = get_posts([
+        'post_type'      => 'empleado',
+        'post_status'    => ['publish','private'],
+        'posts_per_page' => 1,
+        'author'         => (int) $user_id,
+        'fields'         => 'ids',
+    ]);
+    return $posts ? (int)$posts[0] : 0;
+}
+
+// Puntuación total interoperable con cdb-grafica (filtro) + fallback por meta
+function cdb_empleado_get_total_score( $empleado_id ){
+    $from_filter = apply_filters('cdb_grafica/get_total_empleado', null, (int)$empleado_id);
+    if (is_numeric($from_filter)) return (float)$from_filter;
+
+    $from_meta = get_post_meta($empleado_id, '_cdb_total_grafica_empleado', true);
+    return is_numeric($from_meta) ? (float)$from_meta : null;
+}
+
+// Puesto por ranking descendente de total
+function cdb_empleado_get_rank( $empleado_id ){
+    $my_total = cdb_empleado_get_total_score($empleado_id);
+    if (!is_numeric($my_total)) return null;
+
+    $ids = get_posts([
+        'post_type'      => 'empleado',
+        'post_status'    => ['publish','private'],
+        'fields'         => 'ids',
+        'numberposts'    => -1,
+        'orderby'        => 'ID',
+        'order'          => 'ASC',
+    ]);
+
+    $totales = [];
+    foreach ($ids as $id){
+        $t = cdb_empleado_get_total_score($id);
+        if (is_numeric($t)) $totales[(int)$id] = (float)$t;
+    }
+    if (!$totales) return null;
+
+    arsort($totales, SORT_NUMERIC);
+    $rank = array_search((int)$empleado_id, array_keys($totales), true);
+    return is_int($rank) ? ($rank + 1) : null;
+}

--- a/inc/funciones-extra.php
+++ b/inc/funciones-extra.php
@@ -148,27 +148,9 @@ function cdb_inyectar_equipos_del_empleado_en_contenido($content) {
         $attrs        = array('id_suffix' => 'content');
         $grafica_html = apply_filters('cdb_grafica_empleado_html', '', $empleado_id, $attrs);
 
-        if ( apply_filters( 'cdb_empleado_use_new_card', false ) ) {
-            ob_start();
-            $empleado_id = get_the_ID();
-            include plugin_dir_path( __DIR__ ) . 'templates/empleado-card-oct.php';
-            $tarjeta_oct = ob_get_clean();
-            $card_html   = $tarjeta_oct;
-        } else {
-            $empleado_author = (int) get_post_field('post_author', $empleado_id);
-            $disponible      = ('1' === get_post_meta($empleado_id, 'disponible', true));
-            $total           = (float) apply_filters('cdb_grafica_empleado_total', 0, $empleado_id);
-
-            $card_html  = '<div class="cdb-empleado-card">';
-            $card_html .= '<div class="cdb-empleado-card__avatar">' . get_avatar($empleado_author, 96) . '</div>';
-            $card_html .= '<div class="cdb-empleado-card__name">' . esc_html(get_the_title($empleado_id)) . '</div>';
-            $card_html .= '<div class="cdb-pill ' . ($disponible ? 'ok' : 'off') . '">';
-            $card_html .= $disponible ? __('Disponible', 'cdb-empleado') : __('No disponible', 'cdb-empleado');
-            $card_html .= '</div>';
-            $card_html .= '<div class="cdb-empleado-card__score" aria-label="Puntuación total">'
-                        .  number_format_i18n($total, 0) . '</div>';
-            $card_html .= '</div>';
-        }
+        ob_start();
+        cdb_empleado_render_profile_card( $empleado_id );
+        $card_html = ob_get_clean();
 
         $hero_html  = '<section class="cdb-empleado-hero">';
         $hero_html .= $card_html;

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -1,0 +1,10 @@
+<?php
+add_shortcode('cdb_tarjeta_empleado', function($atts){
+    $atts = shortcode_atts(['empleado_id'=>0,'debug'=>'0'], $atts);
+    $empleado_id = $atts['empleado_id'] ? (int)$atts['empleado_id'] : cdb_empleado_get_post_by_author( get_current_user_id() );
+    if (!$empleado_id) return '';
+
+    ob_start();
+    include CDB_EMPLEADO_PLUGIN_DIR . 'templates/empleado-card-oct.php';
+    return ob_get_clean();
+});

--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -100,5 +100,36 @@ function cdb_empleado_get_rank_current( int $empleado_id ): ?int {
     return apply_filters( 'cdb_empleado_rank_current', $rank, $empleado_id );
 }
 
+/**
+ * Renderiza la tarjeta de perfil del empleado.
+ *
+ * @param int $empleado_id Opcional. ID del empleado. Usa el post actual si es 0.
+ */
+function cdb_empleado_render_profile_card( $empleado_id = 0 ) {
+    $empleado_id = $empleado_id ? (int) $empleado_id : get_the_ID();
+    if ( apply_filters( 'cdb_empleado_use_new_card', false ) ) {
+        // NUEVA tarjeta
+        $tpl = CDB_EMPLEADO_PLUGIN_DIR . 'templates/empleado-card-oct.php';
+        if ( file_exists( $tpl ) ) {
+            include $tpl; // usa $empleado_id dentro de la plantilla
+        }
+        return; // evita imprimir la tarjeta antigua
+    }
+
+    $empleado_author = (int) get_post_field( 'post_author', $empleado_id );
+    $disponible      = ( '1' === get_post_meta( $empleado_id, 'disponible', true ) );
+    $total           = (float) apply_filters( 'cdb_grafica_empleado_total', 0, $empleado_id );
+
+    echo '<div class="cdb-empleado-card">';
+    echo '<div class="cdb-empleado-card__avatar">' . get_avatar( $empleado_author, 96 ) . '</div>';
+    echo '<div class="cdb-empleado-card__name">' . esc_html( get_the_title( $empleado_id ) ) . '</div>';
+    echo '<div class="cdb-pill ' . ( $disponible ? 'ok' : 'off' ) . '">';
+    echo $disponible ? __( 'Disponible', 'cdb-empleado' ) : __( 'No disponible', 'cdb-empleado' );
+    echo '</div>';
+    echo '<div class="cdb-empleado-card__score" aria-label="Puntuación total">' .
+         number_format_i18n( $total, 0 ) . '</div>';
+    echo '</div>';
+}
+
 // Feature flag: nueva tarjeta desactivada por defecto.
 add_filter( 'cdb_empleado_use_new_card', '__return_false' );

--- a/templates/empleado-card-oct.php
+++ b/templates/empleado-card-oct.php
@@ -1,87 +1,27 @@
 <?php
-/** Plantilla tarjeta octogonal 3×3 */
-if ( ! function_exists('cdb_empleado_get_card_data') ) return;
-
-$empleado_id = $empleado_id ?? get_the_ID();
-$data        = cdb_empleado_get_card_data( (int)$empleado_id );
-$name        = $data['name'] ?? '';
-$rank        = $data['rank_current'] ?? null;
-$history     = $data['rank_history'] ?? [null,null,null];
-$top_groups  = $data['top_groups'] ?? [];
-$badges      = array_slice( (array)($data['badges'] ?? []), 0, 3 );
-$card_id     = 'empcard8-'.(int)$empleado_id;
+/**
+ * Tarjeta octogonal 3×3 para CPT empleado.
+ * Espera: $empleado_id (int)
+ */
+$empleado_title = get_the_title($empleado_id);
+$puesto = cdb_empleado_get_rank($empleado_id);
 ?>
-<div class="cdb-empcard8" role="group" aria-labelledby="<?php echo esc_attr($card_id); ?>" aria-describedby="<?php echo esc_attr($card_id); ?>-desc">
-  <div class="cdb-empcard8__name" id="<?php echo esc_attr($card_id); ?>" title="<?php echo esc_attr($name); ?>">
-    <?php echo esc_html( $name ); ?>
-  </div>
+<div class="cdb-card-oct" role="region" aria-label="<?php esc_attr_e('Tarjeta de empleado', 'cdb'); ?>">
+  <div class="cdb-card-oct__inner">
+    <h3 class="cdb-card-oct__name"><?php echo esc_html($empleado_title); ?></h3>
 
-  <div class="cdb-empcard8__badges" aria-label="<?php esc_attr_e('Insignias', 'cdb-empleado'); ?>">
-    <?php if ($badges): foreach ($badges as $b): ?>
-      <span class="cdb-empcard8__badge" title="<?php echo esc_attr($b['label'] ?? ''); ?>"></span>
-    <?php endforeach; else: ?>
-      <span class="cdb-empcard8__badge is-empty" aria-hidden="true">—</span>
-      <span class="cdb-empcard8__badge is-empty" aria-hidden="true">—</span>
-      <span class="cdb-empcard8__badge is-empty" aria-hidden="true">—</span>
-    <?php endif; ?>
-  </div>
-
-  <div class="cdb-empcard8__center" aria-hidden="true">
-    <!-- Silueta neutra SVG -->
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor" focusable="false">
-      <circle cx="128" cy="84" r="36"/><rect x="104" y="116" width="48" height="28" rx="10" ry="10"/>
-      <path d="M64 224v-16c0-33.1 28.7-60 64-60s64 26.9 64 60v16H64z"/>
-    </svg>
-  </div>
-
-  <div class="cdb-empcard8__rank">
-    <span class="cdb-empcard8__rank-label"><?php esc_html_e('Puesto', 'cdb-empleado'); ?></span>
-    <span class="cdb-empcard8__rank-value" title="<?php esc_attr_e('Puesto en el ranking total de empleados', 'cdb-empleado'); ?>">
-      <?php echo $rank ? esc_html( number_format_i18n( (int)$rank ) ) : 'ND'; ?>
-    </span>
-  </div>
-
-  <div class="cdb-empcard8__footer">
-    <div class="cdb-empcard8__positions">
-      <span class="cdb-empcard8__section-title"><?php esc_html_e('Últimas posiciones', 'cdb-empleado'); ?></span>
-      <ul class="cdb-empcard8__positions-list" aria-label="<?php esc_attr_e('Tres últimas posiciones', 'cdb-empleado'); ?>">
-        <?php for ($i=0; $i<3; $i++): ?>
-          <?php $val = $history[$i] ?? null; ?>
-          <li class="cdb-empcard8__pos"><?php echo $val ? esc_html( (int)$val ) : '—'; ?></li>
-        <?php endfor; ?>
-      </ul>
+    <div class="cdb-card-oct__avatar" aria-hidden="true">
+      <svg viewBox="0 0 64 64" class="cdb-card-oct__svg" focusable="false" aria-hidden="true">
+        <circle cx="32" cy="24" r="10"></circle>
+        <path d="M12,56 C12,43 52,43 52,56 Z"></path>
+      </svg>
     </div>
-    <div class="cdb-empcard8__groups">
-      <span class="cdb-empcard8__section-title"><?php esc_html_e('Top grupos', 'cdb-empleado'); ?></span>
-      <ul class="cdb-empcard8__groups-list" aria-label="<?php esc_attr_e('Tres grupos con mayor promedio', 'cdb-empleado'); ?>">
-        <?php
-        $top_groups = array_slice( (array)$top_groups, 0, 3 );
-        if ( $top_groups ) :
-          foreach ( $top_groups as $g ) :
-            $k = strtoupper( (string)($g['key'] ?? '') );
-            $v = isset($g['avg']) ? round((float)$g['avg'], 1) : null;
-        ?>
-          <li class="cdb-empcard8__grp">
-            <span class="cdb-empcard8__grp-code"><?php echo esc_html($k ?: '—'); ?></span>
-            <span class="cdb-empcard8__grp-val"><?php echo is_null($v) ? '—' : esc_html( number_format_i18n($v,1) ); ?></span>
-          </li>
-        <?php
-          endforeach;
-        else :
-        ?>
-          <li class="cdb-empcard8__grp is-empty">—</li>
-          <li class="cdb-empcard8__grp is-empty">—</li>
-          <li class="cdb-empcard8__grp is-empty">—</li>
-        <?php endif; ?>
-      </ul>
+
+    <div class="cdb-card-oct__rank" aria-label="<?php esc_attr_e('Puesto en ranking', 'cdb'); ?>">
+      <span class="cdb-card-oct__rank-label"><?php esc_html_e('Puesto', 'cdb'); ?></span>
+      <span class="cdb-card-oct__rank-num">
+        <?php echo is_numeric($puesto) ? esc_html(str_pad((string)$puesto, 2, '0', STR_PAD_LEFT)) : '--'; ?>
+      </span>
     </div>
   </div>
-
-  <span id="<?php echo esc_attr($card_id); ?>-desc" class="screen-reader-text">
-    <?php
-      $r = $rank ? sprintf( __( 'Puesto %d.', 'cdb-empleado' ), (int)$rank ) : __( 'Puesto no disponible.', 'cdb-empleado' );
-      echo esc_html( $r );
-    ?>
-  </span>
 </div>
-


### PR DESCRIPTION
## Summary
- force new octagonal card for employees and load dedicated styles
- provide helpers and template for rank-based card rendering
- add shortcode and update content flow to use the new card

## Testing
- `php -l cdb-empleado.php`
- `php -l inc/card-oct-helpers.php`
- `php -l includes/shortcodes.php`
- `php -l templates/empleado-card-oct.php`
- `php -l includes/template-tags.php`
- `php -l inc/funciones-extra.php`


------
https://chatgpt.com/codex/tasks/task_e_68a7c24561308327aaaae2bbb05de269