### PR TITLE
Add octagonal employee card layout with synced chart

### DIFF
--- a/assets/css/empleado-card-oct.css
+++ b/assets/css/empleado-card-oct.css
@@ -1,22 +1,26 @@
-:root{
-  --cdb-ink:#4a453c; --cdb-ink-2:#6a6459; --cdb-paper:#f3eedf;
-  --cdb-shadow:0 1px 0 rgba(0,0,0,.04),0 6px 18px rgba(0,0,0,.06);
-  --pad:clamp(10px,2.2vw,24px); --name-size:clamp(18px,2.4vw,26px);
-  --avatar-max:clamp(110px,36%,180px); --rank-label:clamp(8px,.9vw,10px);
-  --rank-num:clamp(18px,3.1vw,32px); --row-gap:clamp(6px,1.4vw,16px);
-}
-.cdb-card-oct{
-  --cut:29.2893%;
-  width:min(92vw,560px); aspect-ratio:1/1;
+/* Layout 2 columnas con tamaño compartido */
+.cdb-vis-pair{ --vis-size:clamp(320px,32vw,520px); --vis-gap:clamp(16px,3vw,36px);
+  display:grid; grid-template-columns:1fr 1fr; gap:var(--vis-gap); align-items:start; justify-content:center; }
+.cdb-vis-pair__card, .cdb-vis-pair__chart{ display:flex; justify-content:center; }
+.cdb-vis-pair__card .cdb-card-oct{ width:var(--vis-size); aspect-ratio:1/1; }
+.cdb-vis-pair__chart .cdb-radar-emp{ width:var(--vis-size); aspect-ratio:1/1; }
+.cdb-vis-pair__chart .cdb-radar-emp canvas{ width:100% !important; height:100% !important; } /* cuadrado aunque Chart.js mantenga ratio */
+@media (max-width:900px){ .cdb-vis-pair{ grid-template-columns:1fr; } }
+
+/* Estética similar al mockup */
+.cdb-card-oct{ --cut:29.2893%;
+  background:#f3eedf; color:#4a453c; border:3px solid #4a453c; border-radius:18px;
   clip-path:polygon(var(--cut) 0%,calc(100% - var(--cut)) 0%,100% var(--cut),100% calc(100% - var(--cut)),
                    calc(100% - var(--cut)) 100%,var(--cut) 100%,0% calc(100% - var(--cut)),0% var(--cut));
-  background:var(--cdb-paper); border:1.5px solid var(--cdb-ink-2); box-shadow:var(--cdb-shadow); color:var(--cdb-ink);
-  display:grid; place-items:stretch; font-family:ui-sans-serif,system-ui,-apple-system,"Helvetica Neue",Arial;
+  box-shadow:0 1px 0 rgba(0,0,0,.04),0 6px 18px rgba(0,0,0,.06); display:grid; place-items:stretch;
+  font-family:ui-sans-serif,system-ui,-apple-system,"Helvetica Neue",Arial;
 }
-.cdb-card-oct__inner{ display:grid; grid-template-columns:repeat(3,1fr); grid-template-rows:.9fr 1.2fr .9fr; gap:var(--row-gap); padding:var(--pad); }
-.cdb-card-oct__name{ grid-column:2/3; grid-row:1/2; place-self:center; margin:0; font-size:var(--name-size); font-weight:700; letter-spacing:.06em; text-transform:uppercase; text-align:center; }
+.cdb-card-oct__inner{ display:grid; grid-template-columns:repeat(3,1fr); grid-template-rows:.9fr 1.2fr .9fr;
+  gap:clamp(6px,1.2vw,18px); padding:clamp(14px,2.4vw,26px); }
+.cdb-card-oct__name{ grid-column:2/3; grid-row:1/2; place-self:center; margin:0; text-transform:uppercase;
+  text-align:center; font-weight:800; letter-spacing:.06em; font-size:clamp(22px,2.8vw,34px); }
 .cdb-card-oct__avatar{ grid-column:2/3; grid-row:2/3; place-self:center; }
-.cdb-card-oct__svg{ display:block; width:var(--avatar-max); height:auto; fill:#6f6a60; }
-.cdb-card-oct__rank{ grid-column:3/4; grid-row:2/3; align-self:center; justify-self:end; display:flex; flex-direction:column; align-items:center; gap:2px; text-align:center; transform:translateY(-4%); }
-.cdb-card-oct__rank-label{ font-size:var(--rank-label); letter-spacing:.14em; text-transform:uppercase; opacity:.72; }
-.cdb-card-oct__rank-num{ font-size:var(--rank-num); line-height:1; font-weight:700; letter-spacing:.02em; border:1px solid var(--cdb-ink-2); padding:.18em .36em; border-radius:8px; background:#f6f2e6; }
+.cdb-card-oct__svg{ width:clamp(120px,40%,220px); height:auto; fill:#5e5a51; }
+.cdb-card-oct__rank{ grid-column:3/4; grid-row:2/3; align-self:center; justify-self:end; display:flex; flex-direction:column; align-items:center; gap:4px; transform:translateY(-4%); }
+.cdb-card-oct__rank-label{ font-size:clamp(10px,1.1vw,14px); letter-spacing:.14em; opacity:.82; }
+.cdb-card-oct__rank-num{ font-size:clamp(28px,4vw,60px); font-weight:800; line-height:1; letter-spacing:.02em; }

--- a/assets/js/empleado-card-oct.js
+++ b/assets/js/empleado-card-oct.js
@@ -1,0 +1,10 @@
+(function(){
+  const sync = () => document.querySelectorAll('.cdb-vis-pair').forEach(pair=>{
+    const chart = pair.querySelector('.cdb-radar-emp'); if (!chart) return;
+    const w = Math.round(chart.getBoundingClientRect().width);
+    if (w>0) pair.style.setProperty('--vis-size', w + 'px');
+  });
+  const ro = new ResizeObserver(sync);
+  document.addEventListener('DOMContentLoaded', ()=>{ document.querySelectorAll('.cdb-vis-pair .cdb-radar-emp').forEach(el=>ro.observe(el)); sync(); });
+  window.addEventListener('load', sync);
+})();

--- a/cdb-empleado.php
+++ b/cdb-empleado.php
@@ -333,24 +333,26 @@ register_deactivation_hook( __FILE__, array( 'Cdb_Empleado_Plugin', 'desactivar'
 // Instanciar el plugin.
 new Cdb_Empleado_Plugin();
 
-// Fuerza el uso de la nueva tarjeta en el CPT empleado.
+// Activar nueva tarjeta en CPT
 add_filter( 'cdb_empleado_use_new_card', '__return_true', 99 );
 
+// Estilos/JS: cargar nuevos y desactivar antiguos
 add_action( 'wp_enqueue_scripts', function () {
-    $use_new = apply_filters( 'cdb_empleado_use_new_card', false );
+    wp_dequeue_style( 'cdb-perfil-empleado' );
+    wp_deregister_style( 'cdb-perfil-empleado' );
 
-    if ( $use_new ) {
-        // Desactiva estilos antiguos de la tarjeta clásica
-        wp_dequeue_style( 'cdb-perfil-empleado' );
-        wp_deregister_style( 'cdb-perfil-empleado' );
-
-        // Estilos de la tarjeta octogonal
-        wp_enqueue_style(
-            'cdb-empleado-card-oct',
-            CDB_EMPLEADO_PLUGIN_URL . 'assets/css/empleado-card-oct.css',
-            [],
-            '1.0.0'
-        );
-    }
+    wp_enqueue_style(
+        'cdb-empleado-card-oct',
+        CDB_EMPLEADO_PLUGIN_URL . 'assets/css/empleado-card-oct.css',
+        [],
+        '1.1.0'
+    );
+    wp_enqueue_script(
+        'cdb-empleado-card-oct',
+        CDB_EMPLEADO_PLUGIN_URL . 'assets/js/empleado-card-oct.js',
+        [],
+        '1.0.0',
+        true
+    );
 }, 20 );
 

--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -108,12 +108,17 @@ function cdb_empleado_get_rank_current( int $empleado_id ): ?int {
 function cdb_empleado_render_profile_card( $empleado_id = 0 ) {
     $empleado_id = $empleado_id ? (int) $empleado_id : get_the_ID();
     if ( apply_filters( 'cdb_empleado_use_new_card', false ) ) {
-        // NUEVA tarjeta
-        $tpl = CDB_EMPLEADO_PLUGIN_DIR . 'templates/empleado-card-oct.php';
-        if ( file_exists( $tpl ) ) {
-            include $tpl; // usa $empleado_id dentro de la plantilla
-        }
-        return; // evita imprimir la tarjeta antigua
+        $empleado_id = get_the_ID();
+        echo '<section class="cdb-vis-pair" data-cdb-vis="pair">';
+          echo '<div class="cdb-vis-pair__card">';
+            include CDB_EMPLEADO_PLUGIN_DIR . 'templates/empleado-card-oct.php';
+          echo '</div>';
+          echo '<div class="cdb-vis-pair__chart">';
+            // La gráfica se inyectará desde cdb-grafica en el siguiente prompt
+            do_action( 'cdb_grafica/render_radar_empleado', $empleado_id );
+          echo '</div>';
+        echo '</section>';
+        return; // evita render legacy
     }
 
     $empleado_author = (int) get_post_field( 'post_author', $empleado_id );

--- a/templates/empleado-card-oct.php
+++ b/templates/empleado-card-oct.php
@@ -3,25 +3,21 @@
  * Tarjeta octogonal 3×3 para CPT empleado.
  * Espera: $empleado_id (int)
  */
-$empleado_title = get_the_title($empleado_id);
-$puesto = cdb_empleado_get_rank($empleado_id);
+$empleado_title = strtoupper( get_the_title( $empleado_id ) );
+$puesto         = cdb_empleado_get_rank( $empleado_id );
 ?>
-<div class="cdb-card-oct" role="region" aria-label="<?php esc_attr_e('Tarjeta de empleado', 'cdb'); ?>">
+<div class="cdb-card-oct" role="region" aria-label="<?php esc_attr_e( 'Tarjeta de empleado', 'cdb' ); ?>">
   <div class="cdb-card-oct__inner">
-    <h3 class="cdb-card-oct__name"><?php echo esc_html($empleado_title); ?></h3>
-
+    <h3 class="cdb-card-oct__name"><?php echo esc_html( $empleado_title ); ?></h3>
     <div class="cdb-card-oct__avatar" aria-hidden="true">
       <svg viewBox="0 0 64 64" class="cdb-card-oct__svg" focusable="false" aria-hidden="true">
         <circle cx="32" cy="24" r="10"></circle>
         <path d="M12,56 C12,43 52,43 52,56 Z"></path>
       </svg>
     </div>
-
-    <div class="cdb-card-oct__rank" aria-label="<?php esc_attr_e('Puesto en ranking', 'cdb'); ?>">
-      <span class="cdb-card-oct__rank-label"><?php esc_html_e('Puesto', 'cdb'); ?></span>
-      <span class="cdb-card-oct__rank-num">
-        <?php echo is_numeric($puesto) ? esc_html(str_pad((string)$puesto, 2, '0', STR_PAD_LEFT)) : '--'; ?>
-      </span>
+    <div class="cdb-card-oct__rank" aria-label="<?php esc_attr_e( 'Puesto en ranking', 'cdb' ); ?>">
+      <span class="cdb-card-oct__rank-label"><?php esc_html_e( 'PUESTO', 'cdb' ); ?></span>
+      <span class="cdb-card-oct__rank-num"><?php echo is_numeric( $puesto ) ? esc_html( str_pad( (string) $puesto, 2, '0', STR_PAD_LEFT ) ) : '--'; ?></span>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- enable new octagonal employee card and enqueue its assets
- render octagonal card with radar chart in two-column layout
- style card and chart to keep equal square dimensions and show ranking

## Testing
- `php -l cdb-empleado.php`
- `php -l includes/template-tags.php`
- `php -l templates/empleado-card-oct.php`
- `php -l inc/card-oct-helpers.php`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a836b2e1448327a06ea463d8bd4c4a