### PR TITLE
Render employee chart only inside new card

### DIFF
--- a/cdb-empleado.php
+++ b/cdb-empleado.php
@@ -336,6 +336,9 @@ new Cdb_Empleado_Plugin();
 // Activar nueva tarjeta en CPT
 add_filter( 'cdb_empleado_use_new_card', '__return_true', 99 );
 
+// Evita que cdb-grafica auto-inyecte la gráfica del empleado
+add_filter( 'cdb_grafica/auto_render_empleado_chart', '__return_false', 99 );
+
 // Estilos/JS: cargar nuevos y desactivar antiguos
 add_action( 'wp_enqueue_scripts', function () {
     wp_dequeue_style( 'cdb-perfil-empleado' );

--- a/inc/funciones-extra.php
+++ b/inc/funciones-extra.php
@@ -142,20 +142,24 @@ function cdb_inyectar_equipos_del_empleado_en_contenido($content) {
     $is_self = function_exists('cdb_obtener_empleado_id')
         && (int) cdb_obtener_empleado_id( get_current_user_id() ) === (int) $empleado_id;
 
-    if (false === apply_filters('cdb_empleado_inyectar_grafica', true, $empleado_id)) {
+    if ( false === apply_filters( 'cdb_empleado_inyectar_grafica', true, $empleado_id ) ) {
         $hero_html = '';
     } else {
-        $attrs        = array('id_suffix' => 'content');
-        $grafica_html = apply_filters('cdb_grafica_empleado_html', '', $empleado_id, $attrs);
-
         ob_start();
         cdb_empleado_render_profile_card( $empleado_id );
         $card_html = ob_get_clean();
 
-        $hero_html  = '<section class="cdb-empleado-hero">';
-        $hero_html .= $card_html;
-        $hero_html .= '<div class="cdb-empleado-grafica-wrap">' . $grafica_html . '</div>';
-        $hero_html .= '</section>';
+        $hero_html = $card_html;
+
+        if ( false === apply_filters( 'cdb_empleado_use_new_card', false ) ) {
+            $attrs        = array( 'id_suffix' => 'content' );
+            $grafica_html = apply_filters( 'cdb_grafica_empleado_html', '', $empleado_id, $attrs );
+
+            $hero_html  = '<section class="cdb-empleado-hero">';
+            $hero_html .= $card_html;
+            $hero_html .= '<div class="cdb-empleado-grafica-wrap">' . $grafica_html . '</div>';
+            $hero_html .= '</section>';
+        }
     }
 
     $calificacion_block = '';


### PR DESCRIPTION
## Summary
- Enable new employee card and disable cdb-grafica auto rendering
- Avoid duplicate chart injection by rendering card+chart pair once

## Testing
- `php -l cdb-empleado.php`
- `php -l inc/funciones-extra.php`
- `php -l includes/template-tags.php`


------
https://chatgpt.com/codex/tasks/task_e_68a8af2af0048327b67fe65999b10040