### PR TITLE
Add single page overrides for octagonal employee card

### DIFF
--- a/assets/css/empleado-card-oct.css
+++ b/assets/css/empleado-card-oct.css
@@ -61,3 +61,57 @@
   :root{ --cdb8-size: clamp(280px, 96vw, 320px); }
 }
 
+/* Overrides for single empleado view */
+.single-empleado .cdb-empcard8{
+  --cdb8-bg:#F4EFDF; --cdb8-ink:#2B2B2B; --cdb8-border:#00000014; --cdb8-muted:#8E7E60;
+  clip-path: polygon(10% 0, 90% 0, 100% 10%, 100% 90%, 90% 100%, 10% 100%, 0 90%, 0 10%);
+  display:grid;
+  grid-template-columns:1fr 1fr 1fr;
+  grid-template-rows:auto 1fr auto;
+  grid-template-areas:
+    "name   name   name"
+    "badges center rank"
+    "footer footer footer";
+}
+
+.single-empleado .cdb-empcard8__name{
+  grid-area:name;
+  font-size:var(--cdb8-fs-name);
+  font-weight:600;
+  white-space:nowrap;
+  overflow:hidden;
+  text-overflow:ellipsis;
+}
+
+.single-empleado .cdb-empcard8__center{
+  grid-area:center;
+  display:grid;
+  place-items:center;
+}
+
+.single-empleado .cdb-empcard8__center svg{
+  width:var(--cdb8-avatar);
+  height:auto;
+  color:#6B6B6B;
+}
+
+.single-empleado .cdb-empcard8__rank{
+  grid-area:rank;
+  display:grid;
+  align-content:center;
+  justify-items:end;
+  text-align:right;
+}
+
+.single-empleado .cdb-empcard8__rank-label{
+  font-size:var(--cdb8-fs-label);
+  color:var(--cdb8-muted);
+  text-transform:uppercase;
+  letter-spacing:.06em;
+}
+
+.single-empleado .cdb-empcard8__rank-value{
+  font-size:var(--cdb8-fs-rank);
+  line-height:1;
+  font-weight:700;
+}


### PR DESCRIPTION
## Summary
- add CSS overrides for `.single-empleado` pages to keep octagonal employee card layout and tokens

## Testing
- `npx -y stylelint assets/css/empleado-card-oct.css` *(fails: 403 Forbidden fetching stylelint)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e40827b48327bd45e0b4d4dec53d