### PR TITLE
Simplify employee card layout

### DIFF
--- a/assets/css/empleado-card-oct.css
+++ b/assets/css/empleado-card-oct.css
@@ -1,155 +1,64 @@
-:root{
-  /* Tamaño base y escalas */
-  --cdb8-size: clamp(300px, 90vw, 360px);
-  --cdb8-pad: calc(20px * (var(--cdb8-size) / 360));
-  --cdb8-gap: calc(14px * (var(--cdb8-size) / 360));
-  --cdb8-avatar: calc(160px * (var(--cdb8-size) / 360));
-  --cdb8-badge: calc(56px * (var(--cdb8-size) / 360));
-  /* Colores */
-  --cdb8-bg: #F4EFDF;
-  --cdb8-ink: #2B2B2B;
-  --cdb8-border: #00000014;
-  --cdb8-muted: #8E7E60;
-  /* Tipografía */
-  --cdb8-fs-name: clamp(16px, calc(var(--cdb8-size) * 0.065), 28px);
-  --cdb8-fs-label: clamp(10px, calc(var(--cdb8-size) * 0.035), 14px);
-  --cdb8-fs-rank: clamp(28px, calc(var(--cdb8-size) * 0.18), 64px);
-}
-
-/* --- Contenedor principal de la tarjeta --- */
+/* Tarjeta empleado (octágono regular + grid 3×3) */
 .cdb-empcard8{
-  width:min(var(--cdb8-size),100%);
+  /* Tokens locales */
+  --ink:#4a453c; --ink-2:#6a6459; --paper:#f3eedf;
+  --pad:clamp(10px,2.2vw,24px);
+  --gap:clamp(6px,1.4vw,16px);
+  --name-size:clamp(18px,2.4vw,26px);
+  --avatar-max:clamp(110px,36%,180px);
+  --rank-label:clamp(8px,.9vw,10px);
+  --rank-num:clamp(18px,3.1vw,32px);
+
+  /* Caja */
+  width:100%;
   aspect-ratio:1/1;
-  background:var(--cdb8-bg);
-  color:var(--cdb8-ink);
-  border:1.5px solid var(--cdb8-border);
+  background:var(--paper);
+  color:var(--ink);
+  border:3px solid var(--ink);
   border-radius:18px;
-  padding:var(--cdb8-pad);
-  box-shadow:0 8px 22px rgba(0,0,0,.06);
-  display:grid;
-  gap:var(--cdb8-gap);
-  grid-template-columns:1fr 1fr 1fr;
-  grid-template-rows:auto 1fr auto;
-  grid-template-areas:
-    "name   name   name"
-    "badges center rank"
-    "footer footer footer";
-  /* Octógono */
-  clip-path:polygon(10% 0,90% 0,100% 10%,100% 90%,90% 100%,10% 100%,0 90%,0 10%);
-}
+  box-shadow:0 1px 0 rgba(0,0,0,.04), 0 6px 18px rgba(0,0,0,.06);
+  font-family:ui-sans-serif,system-ui,-apple-system,"Helvetica Neue",Arial;
 
-/* --- Áreas principales --- */
-.cdb-empcard8__name{
-  grid-area:name;
-  font-size:var(--cdb8-fs-name);
-  font-weight:600;
-  white-space:nowrap;
-  overflow:hidden;
-  text-overflow:ellipsis;
-}
-.cdb-empcard8__badges{
-  grid-area:badges;
-  display:grid;
-  grid-auto-flow:column;
-  grid-auto-columns:1fr;
-  align-items:center;
-  gap:calc(var(--cdb8-gap)*0.6);
-}
-.cdb-empcard8__badge{
-  width:var(--cdb8-badge);
-  height:var(--cdb8-badge);
-  border-radius:999px;
-  border:1px dashed var(--cdb8-border);
-  display:grid;
-  place-items:center;
-  font-weight:600;
-  color:#6b6b6b;
-}
-.cdb-empcard8__badge.is-empty{opacity:.7;}
+  /* Octágono regular (1 - 1/sqrt(2)) */
+  --cut:29.2893%;
+  clip-path:polygon(
+    var(--cut) 0%, calc(100% - var(--cut)) 0%,
+    100% var(--cut), 100% calc(100% - var(--cut)),
+    calc(100% - var(--cut)) 100%, var(--cut) 100%,
+    0% calc(100% - var(--cut)), 0% var(--cut)
+  );
 
-.cdb-empcard8__center{
-  grid-area:center;
-  display:grid;
-  place-items:center;
-}
-.cdb-empcard8__center svg{
-  width:var(--cdb8-avatar);
-  height:auto;
-  color:#6B6B6B;
-}
-
-.cdb-empcard8__rank{
-  grid-area:rank;
-  display:grid;
-  align-content:center;
-  justify-items:end;
-  text-align:right;
-}
-.cdb-empcard8__rank-label{
-  font-size:var(--cdb8-fs-label);
-  color:var(--cdb8-muted);
-  text-transform:uppercase;
-  letter-spacing:.06em;
-}
-.cdb-empcard8__rank-value{
-  font-size:var(--cdb8-fs-rank);
-  line-height:1;
-  font-weight:700;
-}
-
-/* --- Sección inferior --- */
-.cdb-empcard8__footer{
-  grid-area:footer;
-  display:grid;
-  gap:calc(var(--cdb8-gap)*0.8);
-}
-.cdb-empcard8__section-title{
-  font-size:var(--cdb8-fs-label);
-  color:var(--cdb8-muted);
-  text-transform:uppercase;
-  letter-spacing:.06em;
-}
-.cdb-empcard8__positions-list,
-.cdb-empcard8__groups-list{
+  /* Grid 3×3 */
   display:grid;
   grid-template-columns:repeat(3,1fr);
-  gap:calc(var(--cdb8-gap)*0.5);
-  list-style:none;
-  padding:0;
-  margin:0;
-}
-.cdb-empcard8__pos{
-  display:grid;
-  place-items:center;
-  min-height:2.2em;
-  border:1px solid var(--cdb8-border);
-  border-radius:999px;
-  font-weight:600;
-}
-.cdb-empcard8__grp{
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  gap:.4em;
-  min-height:2.2em;
-  border:1px solid var(--cdb8-border);
-  border-radius:999px;
-  padding:0 .7em;
-}
-.cdb-empcard8__grp-code{font-weight:700;}
-.cdb-empcard8__grp-val{opacity:.9;}
-
-/* --- Accesibilidad --- */
-.screen-reader-text{
-  position:absolute !important;
-  height:1px;
-  width:1px;
-  overflow:hidden;
-  clip:rect(1px,1px,1px,1px);
-  white-space:nowrap;
+  grid-template-rows:.9fr 1.2fr .9fr;
+  gap:var(--gap);
+  padding:var(--pad);
 }
 
-/* --- Responsivo: mantiene 3×3 y solo escala --- */
-@media (max-width:420px){
-  :root{--cdb8-size:clamp(280px,96vw,320px);}
+/* F1 C2 — Nombre */
+.cdb-empcard8__name{
+  grid-column:2/3; grid-row:1/2; place-self:center;
+  margin:0; text-align:center; text-transform:uppercase;
+  letter-spacing:.06em; font-weight:800; font-size:var(--name-size);
+  white-space:nowrap; overflow:hidden; text-overflow:ellipsis;
 }
+
+/* F2 C2 — Silueta */
+.cdb-empcard8__center{ grid-column:2/3; grid-row:2/3; place-self:center; }
+.cdb-empcard8__center svg{ width:var(--avatar-max); height:auto; fill:#5e5a51; }
+
+/* F2 C3 — Puesto */
+.cdb-empcard8__rank{
+  grid-column:3/4; grid-row:2/3; align-self:center; justify-self:end;
+  display:flex; flex-direction:column; align-items:center; gap:2px;
+  transform:translateY(-4%); text-align:center;
+}
+.cdb-empcard8__rank-label{
+  font-size:var(--rank-label); letter-spacing:.14em; text-transform:uppercase; opacity:.82;
+}
+.cdb-empcard8__rank-value{
+  font-size:var(--rank-num); line-height:1; font-weight:800; letter-spacing:.02em;
+  border:1px solid var(--ink-2); padding:.18em .36em; border-radius:8px; background:#f6f2e6;
+}
+

--- a/templates/empleado-card-oct.php
+++ b/templates/empleado-card-oct.php
@@ -1,87 +1,34 @@
 <?php
-/** Plantilla tarjeta octogonal 3×3 */
+/** Tarjeta empleado: octágono regular + 3×3 (Nombre, Silueta, Puesto) */
 if ( ! function_exists('cdb_empleado_get_card_data') ) return;
 
 $empleado_id = $empleado_id ?? get_the_ID();
-$data        = cdb_empleado_get_card_data( (int)$empleado_id );
-$name        = $data['name'] ?? '';
-$rank        = $data['rank_current'] ?? null;
-$history     = $data['rank_history'] ?? [null,null,null];
-$top_groups  = $data['top_groups'] ?? [];
-$badges      = array_slice( (array)($data['badges'] ?? []), 0, 3 );
-$card_id     = 'empcard8-'.(int)$empleado_id;
+$data     = cdb_empleado_get_card_data( (int) $empleado_id );
+$name     = $data['name'] ?? '';
+$rank     = $data['rank_current'] ?? null;
+$rank_str = is_numeric($rank) ? str_pad((string)(int)$rank, 2, '0', STR_PAD_LEFT) : 'ND';
+$card_id  = 'empcard8-' . (int) $empleado_id;
 ?>
-<div class="cdb-empcard8" role="group" aria-labelledby="<?php echo esc_attr($card_id); ?>" aria-describedby="<?php echo esc_attr($card_id); ?>-desc">
-  <div class="cdb-empcard8__name" id="<?php echo esc_attr($card_id); ?>" title="<?php echo esc_attr($name); ?>">
-    <?php echo esc_html( $name ); ?>
-  </div>
 
-  <div class="cdb-empcard8__badges" aria-label="<?php esc_attr_e('Insignias', 'cdb-empleado'); ?>">
-    <?php if ($badges): foreach ($badges as $b): ?>
-      <span class="cdb-empcard8__badge" title="<?php echo esc_attr($b['label'] ?? ''); ?>"></span>
-    <?php endforeach; else: ?>
-      <span class="cdb-empcard8__badge is-empty" aria-hidden="true">—</span>
-      <span class="cdb-empcard8__badge is-empty" aria-hidden="true">—</span>
-      <span class="cdb-empcard8__badge is-empty" aria-hidden="true">—</span>
-    <?php endif; ?>
-  </div>
+<div class="cdb-empcard8" role="region" aria-labelledby="<?php echo esc_attr($card_id); ?>">
+  <!-- F1 C2 — Nombre -->
+  <h3 class="cdb-empcard8__name" id="<?php echo esc_attr($card_id); ?>" title="<?php echo esc_attr($name); ?>">
+    <?php echo esc_html($name); ?>
+  </h3>
 
+  <!-- F2 C2 — Silueta -->
   <div class="cdb-empcard8__center" aria-hidden="true">
-    <!-- Silueta neutra SVG -->
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor" focusable="false">
-      <circle cx="128" cy="84" r="36"/><rect x="104" y="116" width="48" height="28" rx="10" ry="10"/>
+      <circle cx="128" cy="84" r="36"/>
+      <rect x="104" y="116" width="48" height="28" rx="10" ry="10"/>
       <path d="M64 224v-16c0-33.1 28.7-60 64-60s64 26.9 64 60v16H64z"/>
     </svg>
   </div>
 
-  <div class="cdb-empcard8__rank">
+  <!-- F2 C3 — Puesto -->
+  <div class="cdb-empcard8__rank" aria-label="<?php esc_attr_e('Puesto en ranking', 'cdb-empleado'); ?>">
     <span class="cdb-empcard8__rank-label"><?php esc_html_e('Puesto', 'cdb-empleado'); ?></span>
-    <span class="cdb-empcard8__rank-value" title="<?php esc_attr_e('Puesto en el ranking total de empleados', 'cdb-empleado'); ?>">
-      <?php echo $rank ? esc_html( number_format_i18n( (int)$rank ) ) : 'ND'; ?>
-    </span>
+    <span class="cdb-empcard8__rank-value"><?php echo esc_html($rank_str); ?></span>
   </div>
-
-  <div class="cdb-empcard8__footer">
-    <div class="cdb-empcard8__positions">
-      <span class="cdb-empcard8__section-title"><?php esc_html_e('Últimas posiciones', 'cdb-empleado'); ?></span>
-      <ul class="cdb-empcard8__positions-list" aria-label="<?php esc_attr_e('Tres últimas posiciones', 'cdb-empleado'); ?>">
-        <?php for ($i=0; $i<3; $i++): ?>
-          <?php $val = $history[$i] ?? null; ?>
-          <li class="cdb-empcard8__pos"><?php echo $val ? esc_html( (int)$val ) : '—'; ?></li>
-        <?php endfor; ?>
-      </ul>
-    </div>
-    <div class="cdb-empcard8__groups">
-      <span class="cdb-empcard8__section-title"><?php esc_html_e('Top grupos', 'cdb-empleado'); ?></span>
-      <ul class="cdb-empcard8__groups-list" aria-label="<?php esc_attr_e('Tres grupos con mayor promedio', 'cdb-empleado'); ?>">
-        <?php
-        $top_groups = array_slice( (array)$top_groups, 0, 3 );
-        if ( $top_groups ) :
-          foreach ( $top_groups as $g ) :
-            $k = strtoupper( (string)($g['key'] ?? '') );
-            $v = isset($g['avg']) ? round((float)$g['avg'], 1) : null;
-        ?>
-          <li class="cdb-empcard8__grp">
-            <span class="cdb-empcard8__grp-code"><?php echo esc_html($k ?: '—'); ?></span>
-            <span class="cdb-empcard8__grp-val"><?php echo is_null($v) ? '—' : esc_html( number_format_i18n($v,1) ); ?></span>
-          </li>
-        <?php
-          endforeach;
-        else :
-        ?>
-          <li class="cdb-empcard8__grp is-empty">—</li>
-          <li class="cdb-empcard8__grp is-empty">—</li>
-          <li class="cdb-empcard8__grp is-empty">—</li>
-        <?php endif; ?>
-      </ul>
-    </div>
-  </div>
-
-  <span id="<?php echo esc_attr($card_id); ?>-desc" class="screen-reader-text">
-    <?php
-      $r = $rank ? sprintf( __( 'Puesto %d.', 'cdb-empleado' ), (int)$rank ) : __( 'Puesto no disponible.', 'cdb-empleado' );
-      echo esc_html( $r );
-    ?>
-  </span>
 </div>
 


### PR DESCRIPTION
## Summary
- Replace octagonal card template with minimal 3×3 grid showing name, silhouette, and formatted rank
- Streamline CSS for card: octagonal shape, grid layout, and compact rank styling

## Testing
- `php -l templates/empleado-card-oct.php`


------
https://chatgpt.com/codex/tasks/task_e_68a8f7edf4ec8327b209948e92c9297c