### PR TITLE
Render employee card with combined SVG path

### DIFF
--- a/assets/css/empleado-card-oct.css
+++ b/assets/css/empleado-card-oct.css
@@ -1,155 +1,16 @@
-:root{
-  /* Tamaño base y escalas */
-  --cdb8-size: clamp(300px, 90vw, 360px);
-  --cdb8-pad: calc(20px * (var(--cdb8-size) / 360));
-  --cdb8-gap: calc(14px * (var(--cdb8-size) / 360));
-  --cdb8-avatar: calc(160px * (var(--cdb8-size) / 360));
-  --cdb8-badge: calc(56px * (var(--cdb8-size) / 360));
-  /* Colores */
-  --cdb8-bg: #F4EFDF;
-  --cdb8-ink: #2B2B2B;
-  --cdb8-border: #00000014;
-  --cdb8-muted: #8E7E60;
-  /* Tipografía */
-  --cdb8-fs-name: clamp(16px, calc(var(--cdb8-size) * 0.065), 28px);
-  --cdb8-fs-label: clamp(10px, calc(var(--cdb8-size) * 0.035), 14px);
-  --cdb8-fs-rank: clamp(28px, calc(var(--cdb8-size) * 0.18), 64px);
-}
-
-/* --- Contenedor principal de la tarjeta --- */
+/* Tarjeta empleado (contorno + silueta en path SVG) */
 .cdb-empcard8{
-  width:min(var(--cdb8-size),100%);
-  aspect-ratio:1/1;
-  background:var(--cdb8-bg);
-  color:var(--cdb8-ink);
-  border:1.5px solid var(--cdb8-border);
-  border-radius:18px;
-  padding:var(--cdb8-pad);
-  box-shadow:0 8px 22px rgba(0,0,0,.06);
-  display:grid;
-  gap:var(--cdb8-gap);
-  grid-template-columns:1fr 1fr 1fr;
-  grid-template-rows:auto 1fr auto;
-  grid-template-areas:
-    "name   name   name"
-    "badges center rank"
-    "footer footer footer";
-  /* Octógono */
-  clip-path:polygon(10% 0,90% 0,100% 10%,100% 90%,90% 100%,10% 100%,0 90%,0 10%);
+  --paper:#f3eedf;
+  --ink:#5c564d;
+  width:100%;
+  aspect-ratio:888/874;
+  background:var(--paper);
+  color:var(--ink);
+  font-family:ui-sans-serif,system-ui,-apple-system,"Helvetica Neue",Arial;
 }
-
-/* --- Áreas principales --- */
-.cdb-empcard8__name{
-  grid-area:name;
-  font-size:var(--cdb8-fs-name);
-  font-weight:600;
-  white-space:nowrap;
-  overflow:hidden;
-  text-overflow:ellipsis;
-}
-.cdb-empcard8__badges{
-  grid-area:badges;
-  display:grid;
-  grid-auto-flow:column;
-  grid-auto-columns:1fr;
-  align-items:center;
-  gap:calc(var(--cdb8-gap)*0.6);
-}
-.cdb-empcard8__badge{
-  width:var(--cdb8-badge);
-  height:var(--cdb8-badge);
-  border-radius:999px;
-  border:1px dashed var(--cdb8-border);
-  display:grid;
-  place-items:center;
-  font-weight:600;
-  color:#6b6b6b;
-}
-.cdb-empcard8__badge.is-empty{opacity:.7;}
-
-.cdb-empcard8__center{
-  grid-area:center;
-  display:grid;
-  place-items:center;
-}
-.cdb-empcard8__center svg{
-  width:var(--cdb8-avatar);
-  height:auto;
-  color:#6B6B6B;
-}
-
-.cdb-empcard8__rank{
-  grid-area:rank;
-  display:grid;
-  align-content:center;
-  justify-items:end;
-  text-align:right;
-}
-.cdb-empcard8__rank-label{
-  font-size:var(--cdb8-fs-label);
-  color:var(--cdb8-muted);
-  text-transform:uppercase;
-  letter-spacing:.06em;
-}
-.cdb-empcard8__rank-value{
-  font-size:var(--cdb8-fs-rank);
-  line-height:1;
-  font-weight:700;
-}
-
-/* --- Sección inferior --- */
-.cdb-empcard8__footer{
-  grid-area:footer;
-  display:grid;
-  gap:calc(var(--cdb8-gap)*0.8);
-}
-.cdb-empcard8__section-title{
-  font-size:var(--cdb8-fs-label);
-  color:var(--cdb8-muted);
-  text-transform:uppercase;
-  letter-spacing:.06em;
-}
-.cdb-empcard8__positions-list,
-.cdb-empcard8__groups-list{
-  display:grid;
-  grid-template-columns:repeat(3,1fr);
-  gap:calc(var(--cdb8-gap)*0.5);
-  list-style:none;
-  padding:0;
-  margin:0;
-}
-.cdb-empcard8__pos{
-  display:grid;
-  place-items:center;
-  min-height:2.2em;
-  border:1px solid var(--cdb8-border);
-  border-radius:999px;
-  font-weight:600;
-}
-.cdb-empcard8__grp{
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  gap:.4em;
-  min-height:2.2em;
-  border:1px solid var(--cdb8-border);
-  border-radius:999px;
-  padding:0 .7em;
-}
-.cdb-empcard8__grp-code{font-weight:700;}
-.cdb-empcard8__grp-val{opacity:.9;}
-
-/* --- Accesibilidad --- */
-.screen-reader-text{
-  position:absolute !important;
-  height:1px;
-  width:1px;
-  overflow:hidden;
-  clip:rect(1px,1px,1px,1px);
-  white-space:nowrap;
-}
-
-/* --- Responsivo: mantiene 3×3 y solo escala --- */
-@media (max-width:420px){
-  :root{--cdb8-size:clamp(280px,96vw,320px);}
-}
+.cdb-empcard8 svg{width:100%;height:auto;display:block;}
+.cdb-empcard8 .t{fill:var(--ink);font-weight:800;letter-spacing:.06em;}
+.cdb-empcard8 .t--small{font-weight:700;letter-spacing:.12em;}
+.cdb-empcard8 .name{transform:translate(0,-8px);}
+.cdb-empcard8 .puesto{transform:translate(0,0);}
+.cdb-empcard8 .num{transform:translate(0,4px);}

--- a/templates/empleado-card-oct.php
+++ b/templates/empleado-card-oct.php
@@ -1,87 +1,33 @@
 <?php
-/** Plantilla tarjeta octogonal 3×3 */
+/** Tarjeta empleado: contorno + silueta en un path */
 if ( ! function_exists('cdb_empleado_get_card_data') ) return;
 
 $empleado_id = $empleado_id ?? get_the_ID();
-$data        = cdb_empleado_get_card_data( (int)$empleado_id );
-$name        = $data['name'] ?? '';
-$rank        = $data['rank_current'] ?? null;
-$history     = $data['rank_history'] ?? [null,null,null];
-$top_groups  = $data['top_groups'] ?? [];
-$badges      = array_slice( (array)($data['badges'] ?? []), 0, 3 );
-$card_id     = 'empcard8-'.(int)$empleado_id;
+$data     = cdb_empleado_get_card_data( (int) $empleado_id );
+$name     = $data['name'] ?? '';
+$rank     = $data['rank_current'] ?? null;
+$rank_str = is_numeric($rank) ? str_pad((string)(int)$rank, 2, '0', STR_PAD_LEFT) : 'ND';
+$card_id  = 'empcard8-' . (int) $empleado_id;
+
+$parts  = preg_split('/\s+/', trim($name));
+$first  = array_shift($parts);
+$second = $parts ? implode(' ', $parts) : '';
 ?>
-<div class="cdb-empcard8" role="group" aria-labelledby="<?php echo esc_attr($card_id); ?>" aria-describedby="<?php echo esc_attr($card_id); ?>-desc">
-  <div class="cdb-empcard8__name" id="<?php echo esc_attr($card_id); ?>" title="<?php echo esc_attr($name); ?>">
-    <?php echo esc_html( $name ); ?>
-  </div>
-
-  <div class="cdb-empcard8__badges" aria-label="<?php esc_attr_e('Insignias', 'cdb-empleado'); ?>">
-    <?php if ($badges): foreach ($badges as $b): ?>
-      <span class="cdb-empcard8__badge" title="<?php echo esc_attr($b['label'] ?? ''); ?>"></span>
-    <?php endforeach; else: ?>
-      <span class="cdb-empcard8__badge is-empty" aria-hidden="true">—</span>
-      <span class="cdb-empcard8__badge is-empty" aria-hidden="true">—</span>
-      <span class="cdb-empcard8__badge is-empty" aria-hidden="true">—</span>
-    <?php endif; ?>
-  </div>
-
-  <div class="cdb-empcard8__center" aria-hidden="true">
-    <!-- Silueta neutra SVG -->
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor" focusable="false">
-      <circle cx="128" cy="84" r="36"/><rect x="104" y="116" width="48" height="28" rx="10" ry="10"/>
-      <path d="M64 224v-16c0-33.1 28.7-60 64-60s64 26.9 64 60v16H64z"/>
-    </svg>
-  </div>
-
-  <div class="cdb-empcard8__rank">
-    <span class="cdb-empcard8__rank-label"><?php esc_html_e('Puesto', 'cdb-empleado'); ?></span>
-    <span class="cdb-empcard8__rank-value" title="<?php esc_attr_e('Puesto en el ranking total de empleados', 'cdb-empleado'); ?>">
-      <?php echo $rank ? esc_html( number_format_i18n( (int)$rank ) ) : 'ND'; ?>
-    </span>
-  </div>
-
-  <div class="cdb-empcard8__footer">
-    <div class="cdb-empcard8__positions">
-      <span class="cdb-empcard8__section-title"><?php esc_html_e('Últimas posiciones', 'cdb-empleado'); ?></span>
-      <ul class="cdb-empcard8__positions-list" aria-label="<?php esc_attr_e('Tres últimas posiciones', 'cdb-empleado'); ?>">
-        <?php for ($i=0; $i<3; $i++): ?>
-          <?php $val = $history[$i] ?? null; ?>
-          <li class="cdb-empcard8__pos"><?php echo $val ? esc_html( (int)$val ) : '—'; ?></li>
-        <?php endfor; ?>
-      </ul>
-    </div>
-    <div class="cdb-empcard8__groups">
-      <span class="cdb-empcard8__section-title"><?php esc_html_e('Top grupos', 'cdb-empleado'); ?></span>
-      <ul class="cdb-empcard8__groups-list" aria-label="<?php esc_attr_e('Tres grupos con mayor promedio', 'cdb-empleado'); ?>">
-        <?php
-        $top_groups = array_slice( (array)$top_groups, 0, 3 );
-        if ( $top_groups ) :
-          foreach ( $top_groups as $g ) :
-            $k = strtoupper( (string)($g['key'] ?? '') );
-            $v = isset($g['avg']) ? round((float)$g['avg'], 1) : null;
-        ?>
-          <li class="cdb-empcard8__grp">
-            <span class="cdb-empcard8__grp-code"><?php echo esc_html($k ?: '—'); ?></span>
-            <span class="cdb-empcard8__grp-val"><?php echo is_null($v) ? '—' : esc_html( number_format_i18n($v,1) ); ?></span>
-          </li>
-        <?php
-          endforeach;
-        else :
-        ?>
-          <li class="cdb-empcard8__grp is-empty">—</li>
-          <li class="cdb-empcard8__grp is-empty">—</li>
-          <li class="cdb-empcard8__grp is-empty">—</li>
+<div class="cdb-empcard8">
+  <svg viewBox="0 0 888 874" role="img" aria-labelledby="<?php echo esc_attr($card_id); ?>">
+    <title id="<?php echo esc_attr($card_id); ?>"><?php echo esc_html($name); ?></title>
+    <path fill-rule="evenodd" fill="currentColor" d="M232.1000,0.000 C374.319,0.333 515.681,0.667 657.000,1.000 C675.888,6.356 708.478,48.477 723.000,63.000 C775.995,116.328 829.005,169.672 882.000,223.000 C894.651,244.303 880.569,341.086 884.1000,362.1000 C886.952,372.652 886.110,406.204 884.000,408.1000 C884.333,450.329 884.667,491.671 884.1000,533.000 C886.856,549.043 889.484,631.699 884.000,645.1000 C875.917,667.078 847.395,685.608 832.000,700.1000 C798.003,734.997 763.997,769.003 729.1000,803.000 C714.075,819.272 678.428,865.408 657.000,872.1000 C587.340,873.333 517.660,873.667 448.000,873.1000 C375.674,873.667 303.326,873.333 230.1000,872.1000 C204.982,863.147 142.196,789.611 117.1000,764.000 C91.669,738.336 65.331,712.664 38.1000,686.1000 C31.001,679.001 22.999,670.999 14.1000,662.1000 C15.333,662.333 15.667,661.667 16.000,661.000 C13.590,659.054 6.701,656.030 3.000,647.1000 C-1.716,637.767 0.282,565.345 1.1000,556.1000 C1.1000,543.668 1.1000,530.332 1.1000,517.000 C1.667,421.676 1.333,326.324 0.1000,230.1000 C5.572,210.880 32.331,192.666 48.1000,175.1000 C51.642,173.359 70.854,156.233 71.000,157.000 C105.042,111.244 154.646,70.353 196.1000,28.000 C204.333,20.667 211.667,13.333 219.000,6.000 C223.666,4.000 228.334,1.1000 232.1000,0.000 ZM288.1000,8.000 C272.728,15.641 236.569,1.249 224.1000,13.000 C175.672,62.995 126.328,113.005 77.000,163.000 C55.335,184.998 33.665,207.002 11.1000,228.1000 C7.472,239.039 9.999,258.626 9.1000,271.1000 C9.1000,311.663 9.1000,351.337 9.1000,390.1000 C9.667,472.992 9.333,555.008 8.1000,636.1000 C25.312,664.518 116.398,752.435 120.1000,753.1000 C120.203,655.625 165.874,617.136 255.1000,595.1000 C266.749,560.987 244.053,556.018 242.000,525.1000 C226.141,525.469 209.941,498.377 216.1000,476.000 C218.616,470.878 224.352,468.666 223.1000,467.000 C229.138,461.533 220.682,431.172 223.1000,415.000 C232.168,375.189 254.857,364.341 297.000,355.000 C307.666,355.1000 318.334,357.000 329.000,358.000 C380.194,371.488 398.387,405.337 387.1000,460.1000 C386.331,469.943 394.215,469.289 396.000,472.1000 C406.944,495.752 384.919,521.285 371.000,527.000 C369.845,544.786 359.965,553.243 355.000,565.000 C355.667,575.332 356.333,585.668 356.1000,595.1000 C375.665,602.333 394.335,608.667 413.000,614.1000 C413.714,615.329 419.892,618.185 416.1000,618.1000 C486.713,647.376 478.154,678.975 494.1000,751.1000 C499.773,772.689 495.966,857.053 504.1000,864.1000 C555.662,864.333 606.338,863.667 657.000,862.1000 C728.660,791.341 800.341,719.659 871.1000,647.1000 C879.950,636.340 874.551,610.866 876.000,593.000 C876.000,548.005 876.000,502.996 876.000,458.000 C875.667,382.341 875.333,306.659 875.000,230.1000 C869.623,215.041 832.084,186.084 816.1000,171.000 C778.337,132.337 739.663,93.663 700.1000,55.000 C689.169,42.025 677.287,23.553 658.000,12.000 C643.030,3.032 583.848,10.242 562.1000,9.000 C471.676,8.667 380.324,8.333 288.1000,8.000 Z" />
+    <g class="t" text-anchor="middle">
+      <text class="name" x="50%" y="155" font-size="90">
+        <tspan x="50%" dy="0"><?php echo esc_html($first); ?></tspan>
+        <?php if ($second !== ''): ?>
+        <tspan x="50%" dy="88"><?php echo esc_html($second); ?></tspan>
         <?php endif; ?>
-      </ul>
-    </div>
-  </div>
-
-  <span id="<?php echo esc_attr($card_id); ?>-desc" class="screen-reader-text">
-    <?php
-      $r = $rank ? sprintf( __( 'Puesto %d.', 'cdb-empleado' ), (int)$rank ) : __( 'Puesto no disponible.', 'cdb-empleado' );
-      echo esc_html( $r );
-    ?>
-  </span>
+      </text>
+    </g>
+    <g class="t t--small" text-anchor="start">
+      <text class="puesto" x="620" y="320" font-size="40"><?php esc_html_e('Puesto', 'cdb-empleado'); ?></text>
+      <text class="num" x="620" y="540" font-size="180" font-weight="900"><?php echo esc_html($rank_str); ?></text>
+    </g>
+  </svg>
 </div>
-


### PR DESCRIPTION
## Summary
- replace card markup with an SVG path that draws the octagon border and silhouette in one shape
- render name and ranking text inside the SVG and split the name across two lines
- streamline stylesheet for the path-based card design

## Testing
- `php -l templates/empleado-card-oct.php`


------
https://chatgpt.com/codex/tasks/task_e_68a8f7edf4ec8327b209948e92c9297c