### PR TITLE
Hide redundant employee titles on single views

### DIFF
--- a/inc/funciones-extra.php
+++ b/inc/funciones-extra.php
@@ -197,3 +197,20 @@ function cdb_inyectar_equipos_del_empleado_en_contenido($content) {
     return $content . $hero_html . $calificacion_block . $shortcode_output;
 }
 add_filter('the_content', 'cdb_inyectar_equipos_del_empleado_en_contenido');
+
+/**
+ * Oculta el título redundante en la vista singular del CPT empleado.
+ *
+ * @param string $title El título del post.
+ * @param int    $id    ID del post actual.
+ *
+ * @return string El título filtrado o vacío en single de empleado.
+ */
+function cdb_empleado_hide_empleado_title( $title, $id ) {
+    if ( is_singular( 'empleado' ) && in_the_loop() && 'empleado' === get_post_type( $id ) ) {
+        return '';
+    }
+
+    return $title;
+}
+add_filter( 'the_title', 'cdb_empleado_hide_empleado_title', 10, 2 );


### PR DESCRIPTION
## Summary
- Suppress duplicate titles on single employee pages by filtering `the_title`
- Register `cdb_empleado_hide_empleado_title` helper to output blank title only in the main loop for `empleado` posts

## Testing
- `php -l inc/funciones-extra.php`

------
https://chatgpt.com/codex/tasks/task_e_68ac80586c288327955739c4b8b9e26a