### PR TITLE
Add configurable role options for employees

### DIFF
--- a/inc/permisos.php
+++ b/inc/permisos.php
@@ -1,15 +1,20 @@
 <?php
 // Asegurar que el archivo no se acceda directamente
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
 /**
  * Hacer que todos los usuarios con permisos adecuados aparezcan en el selector de autores.
  */
-function cdb_mostrar_todos_los_autores($query_args, $r) {
+function cdb_mostrar_todos_los_autores( $query_args, $r ) {
     $query_args['who'] = ''; // Elimina la restricción de solo autores
-    $query_args['role__in'] = ['administrator', 'editor', 'author', 'empleado']; // Agregar más roles si es necesario
+
+    $roles = (array) get_option( 'cdb_empleado_selector_roles', array( 'administrator', 'editor', 'author', 'empleado' ) );
+    if ( ! empty( $roles ) ) {
+        $query_args['role__in'] = $roles;
+    }
+
     return $query_args;
 }
-add_filter('wp_dropdown_users_args', 'cdb_mostrar_todos_los_autores', 10, 2);
+add_filter( 'wp_dropdown_users_args', 'cdb_mostrar_todos_los_autores', 10, 2 );

--- a/inc/roles-capacidades.php
+++ b/inc/roles-capacidades.php
@@ -2,20 +2,29 @@
 /**
  * Definición del rol personalizado "empleado".
  */
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
+/**
+ * Registrar el rol personalizado "empleado".
+ *
+ * Las capacidades extra se obtienen del ajuste "cdb_empleado_extra_caps".
+ */
 function cdb_empleado_registrar_rol() {
-    add_role(
-        'empleado',
-        'Empleado',
-        array(
-            'read' => true,
-        )
-    );
+    $extras = (array) get_option( 'cdb_empleado_extra_caps', array() );
+
+    $caps = array( 'read' => true );
+    foreach ( $extras as $cap ) {
+        $caps[ $cap ] = true;
+    }
+
+    add_role( 'empleado', 'Empleado', $caps );
 }
 
+/**
+ * Eliminar el rol personalizado "empleado".
+ */
 function cdb_empleado_eliminar_rol() {
-    remove_role('empleado');
+    remove_role( 'empleado' );
 }


### PR DESCRIPTION
## Summary
- add Roles submenu with settings for extra capabilities and author selector roles
- allow Employee role to include extra capabilities from settings
- filter user dropdown roles using saved options

## Testing
- `php -l inc/roles-capacidades.php`
- `php -l inc/permisos.php`
- `php -l inc/ajustes.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad0543a91083278a74bee6c15d1f84