### PR TITLE
Enable multi-role author selection

### DIFF
--- a/inc/ajustes.php
+++ b/inc/ajustes.php
@@ -155,8 +155,8 @@ function cdb_empleado_registrar_ajustes_roles() {
         'default'           => array(),
     ) );
 
-    register_setting( 'cdb_empleado_roles', 'cdb_empleado_selector_roles', array(
-        'sanitize_callback' => 'cdb_empleado_sanitizar_roles_selector',
+    register_setting( 'cdb_empleado_roles', 'role_autores', array(
+        'sanitize_callback' => 'cdb_empleado_sanitizar_role_autores',
         'default'           => array( 'administrator', 'editor', 'author', 'empleado' ),
     ) );
 
@@ -176,9 +176,9 @@ function cdb_empleado_registrar_ajustes_roles() {
     );
 
     add_settings_field(
-        'cdb_empleado_selector_roles',
+        'role_autores',
         __( 'Roles permitidos en selector', 'cdb-empleado' ),
-        'cdb_empleado_campo_selector_roles',
+        'cdb_empleado_campo_role_autores',
         'cdb-empleado-roles',
         'cdb_empleado_roles_section'
     );
@@ -262,7 +262,7 @@ function cdb_empleado_sanitizar_caps( $valor ) {
  * @param array $valor Roles enviados.
  * @return array Roles válidos.
  */
-function cdb_empleado_sanitizar_roles_selector( $valor ) {
+function cdb_empleado_sanitizar_role_autores( $valor ) {
     global $wp_roles;
     $todos = array_keys( $wp_roles->roles );
     $valor = is_array( $valor ) ? $valor : array();
@@ -337,13 +337,15 @@ function cdb_empleado_campo_extra_caps() {
 /**
  * Campo para seleccionar roles permitidos en el selector de autores.
  */
-function cdb_empleado_campo_selector_roles() {
-    $valor = (array) get_option( 'cdb_empleado_selector_roles', array( 'administrator', 'editor', 'author', 'empleado' ) );
+function cdb_empleado_campo_role_autores() {
+    $valor = (array) get_option( 'role_autores', array( 'administrator', 'editor', 'author', 'empleado' ) );
     global $wp_roles;
 
+    echo '<select name="role_autores[]" multiple="multiple" size="5">';
     foreach ( $wp_roles->roles as $role_key => $data ) {
-        echo '<label><input type="checkbox" name="cdb_empleado_selector_roles[]" value="' . esc_attr( $role_key ) . '" ' . checked( in_array( $role_key, $valor, true ), true, false ) . ' /> ' . esc_html( $data['name'] ) . '</label><br />';
+        echo '<option value="' . esc_attr( $role_key ) . '" ' . selected( in_array( $role_key, $valor, true ), true, false ) . '>' . esc_html( $data['name'] ) . '</option>';
     }
+    echo '</select>';
 }
 
 /**

--- a/inc/permisos.php
+++ b/inc/permisos.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 function cdb_mostrar_todos_los_autores( $query_args, $r ) {
     $query_args['who'] = ''; // Elimina la restricción de solo autores
 
-    $roles = (array) get_option( 'cdb_empleado_selector_roles', array( 'administrator', 'editor', 'author', 'empleado' ) );
+    $roles = (array) get_option( 'role_autores', array( 'administrator', 'editor', 'author', 'empleado' ) );
     if ( ! empty( $roles ) ) {
         $query_args['role__in'] = $roles;
     }


### PR DESCRIPTION
## Summary
- Add multi-select field for allowed author roles in Roles settings
- Load allowed author roles via `role_autores` option when populating author dropdown

## Testing
- `php -l inc/ajustes.php`
- `php -l inc/permisos.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad0e7ff7a08327b6bf12e170374001