### PR TITLE
Add Textos settings and card extra data options

### DIFF
--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -51,6 +51,7 @@ function cdb_empleado_get_card_data( int $empleado_id ): array {
         'rank_current' => $rank_current,
         'rank_history' => array( null, null, null ),
         'badges'       => array(),
+        'extra'        => array(),
     );
 
     return apply_filters( 'cdb_empleado_card_data', $data, $empleado_id );


### PR DESCRIPTION
## Summary
- add Textos submenu with default notice and extra card data settings
- expose option values through cdb_grafica_empleado_notice and cdb_empleado_card_data filters
- extend card data with slot for extra fields

## Testing
- `php -l inc/ajustes.php`
- `php -l includes/template-tags.php`

------
https://chatgpt.com/codex/tasks/task_e_68ad15d77150832791c45cd7f299cd86