### PR TITLE
Add Empleados submenu to menu

### DIFF
--- a/inc/ajustes.php
+++ b/inc/ajustes.php
@@ -789,6 +789,14 @@ function cdb_empleado_registrar_menu() {
 
     add_submenu_page(
         'cdb-empleado',
+        __( 'Empleados', 'cdb-empleado' ),
+        __( 'Empleados', 'cdb-empleado' ),
+        'edit_posts',
+        'edit.php?post_type=empleado'
+    );
+
+    add_submenu_page(
+        'cdb-empleado',
         __( 'General', 'cdb-empleado' ),
         __( 'General', 'cdb-empleado' ),
         'manage_options',


### PR DESCRIPTION
## Summary
- add Empleados submenu linking to employee posts
- reorder submenus so Empleados appears first

## Testing
- `php -l inc/ajustes.php`


------
https://chatgpt.com/codex/tasks/task_e_68c1e7deb4508327ac157c3c148f6d35