### PR TITLE
Elimina submenú duplicado del listado de empleados

### DIFF
--- a/inc/ajustes.php
+++ b/inc/ajustes.php
@@ -515,12 +515,6 @@ function cdb_empleado_admin_template( $template ) {
 function cdb_empleado_get_submenus() {
     return array(
         array(
-            'slug'       => 'edit.php?post_type=empleado',
-            'title'      => __( 'Empleados', 'cdb-empleado' ),
-            'callback'   => null,
-            'capability' => 'edit_posts',
-        ),
-        array(
             'slug'       => 'cdb-empleado',
             'title'      => __( 'General', 'cdb-empleado' ),
             'callback'   => 'cdb_empleado_pagina_ajustes',


### PR DESCRIPTION
## Resumen
- Se elimina el registro manual de `edit.php?post_type=empleado` en los submenús del plugin, evitando que aparezca dos veces el listado de empleados.

## Pruebas
- `php -l inc/ajustes.php`


------
https://chatgpt.com/codex/tasks/task_e_68c1ef885ea483278a4e34f699eb3def