### PR TITLE
Adjust plugin menu to manage CPT submenu and priority

### DIFF
--- a/inc/ajustes.php
+++ b/inc/ajustes.php
@@ -658,6 +658,8 @@ function cdb_empleado_pagina_textos() {
  * Registrar el menú y submenú de ajustes.
  */
 function cdb_empleado_registrar_menu() {
+    remove_submenu_page( 'cdb-empleado', 'edit.php?post_type=empleado' );
+
     add_menu_page(
         __( 'CdB Empleado', 'cdb-empleado' ),
         __( 'CdB Empleado', 'cdb-empleado' ),
@@ -679,9 +681,17 @@ function cdb_empleado_registrar_menu() {
         );
     }
 
+    add_submenu_page(
+        'cdb-empleado',
+        __( 'Empleados', 'cdb-empleado' ),
+        __( 'Empleados', 'cdb-empleado' ),
+        'edit_posts',
+        'edit.php?post_type=empleado'
+    );
+
     remove_submenu_page( 'cdb-empleado', 'cdb-empleado' );
 }
-add_action( 'admin_menu', 'cdb_empleado_registrar_menu' );
+add_action( 'admin_menu', 'cdb_empleado_registrar_menu', 20 );
 
 /**
  * Encola scripts y estilos para las páginas de ajustes del plugin.


### PR DESCRIPTION
## Summary
- ensure menu registration runs after CPT submenus by setting priority 20
- remove and re-add the employee CPT submenu with the correct "Empleados" label
- keep duplicate top-level submenu removed

## Testing
- `php -l inc/ajustes.php`

------
https://chatgpt.com/codex/tasks/task_e_68c1f9e080d88327bb3c65705c7c67ee