### PR TITLE
feat: add SVG preview for octagonal card

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -8,3 +8,10 @@
 #cdb-empleado-preview .cdb-preview-title {
     margin-top: 0;
 }
+#tarjeta_oct_bg_svg_display {
+    display: none;
+    margin-top: 10px;
+    width: 200px;
+    height: 200px;
+    border: 1px solid #ccc;
+}

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -32,6 +32,10 @@
         });
         $('#tarjeta_oct_font_body, #tarjeta_oct_font_heading').on('change', updatePreview);
         $('#tarjeta_oct_bg_svg').on('input', updatePreview);
+        $('#tarjeta_oct_bg_svg_preview').on('click', function(){
+            var svg = $('#tarjeta_oct_bg_svg').val();
+            $('#tarjeta_oct_bg_svg_display').html(svg).toggle();
+        });
         updatePreview();
     });
 })(jQuery);

--- a/assets/svg/tarjeta-oct-bg.svg
+++ b/assets/svg/tarjeta-oct-bg.svg
@@ -1,1 +1,3 @@
-    <path fill-rule="evenodd"  fill="rgb(102, 96, 78)"
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 888 874">
+  <path fill-rule="evenodd" fill="rgb(102, 96, 78)" d="M100 0h688l100 100v574l-100 100H100L0 674V100L100 0Z"/>
+</svg>

--- a/inc/ajustes.php
+++ b/inc/ajustes.php
@@ -434,6 +434,8 @@ function cdb_empleado_campo_tarjeta_oct_bg() {
 function cdb_empleado_campo_tarjeta_oct_bg_svg() {
     $valor = get_option( 'tarjeta_oct_bg_svg', cdb_empleado_default_bg_svg() );
     echo '<textarea id="tarjeta_oct_bg_svg" name="tarjeta_oct_bg_svg" rows="5" class="large-text code">' . esc_textarea( $valor ) . '</textarea>';
+    echo '<button type="button" id="tarjeta_oct_bg_svg_preview" class="button">' . esc_html__( 'Previsualizar', 'cdb-empleado' ) . '</button>';
+    echo '<div id="tarjeta_oct_bg_svg_display"></div>';
     echo '<p class="description">' . esc_html__( 'SVG que se usará como fondo de la tarjeta.', 'cdb-empleado' ) . '</p>';
 }
 


### PR DESCRIPTION
## Summary
- replace octagonal background asset with full standalone SVG
- allow previewing custom background SVG in settings
- add styles and script to render the SVG preview

## Testing
- `php -l inc/ajustes.php`
- `node --check assets/js/admin.js`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c20cf01c3483278dc2cca6717eda20