### PR TITLE
Strip background SVG wrapper in employee card template

### DIFF
--- a/templates/empleado-card-oct.php
+++ b/templates/empleado-card-oct.php
@@ -12,17 +12,23 @@ $card_id  = 'empcard8-' . (int) $empleado_id;
 $parts = preg_split('/\s+/', trim($name));
 $line1 = mb_strtoupper( $parts[0] ?? '', 'UTF-8' );
 $line2 = isset($parts[1]) ? mb_strtoupper( implode(' ', array_slice($parts,1)), 'UTF-8' ) : '';
+
+$bg_svg = get_option( 'tarjeta_oct_bg_svg', '' );
+if ( '' === $bg_svg ) {
+    $bg_svg = file_get_contents( plugin_dir_path( __FILE__ ) . '../assets/svg/tarjeta-oct-bg.svg' );
+}
+
+$viewBox = '0 0 888 874';
+if ( preg_match( '/<svg[^>]*viewBox=["\']([^"\']+)["\']/i', $bg_svg, $m ) ) {
+    $viewBox = $m[1];
+}
+
+$bg_svg = preg_replace( '/<\/??svg[^>]*>/', '', $bg_svg );
 ?>
 
 <div class="cdb-empcard8" role="region" aria-labelledby="<?php echo esc_attr($card_id); ?>">
-  <svg viewBox="0 0 888 874" aria-label="<?php esc_attr_e('Tarjeta empleado', 'cdb-empleado'); ?>">
-    <?php
-    $bg_svg = get_option( 'tarjeta_oct_bg_svg', '' );
-    if ( '' === $bg_svg ) {
-        $bg_svg = file_get_contents( plugin_dir_path( __FILE__ ) . '../assets/svg/tarjeta-oct-bg.svg' );
-    }
-    echo $bg_svg;
-    ?>
+  <svg viewBox="<?php echo esc_attr( $viewBox ); ?>" aria-label="<?php esc_attr_e('Tarjeta empleado', 'cdb-empleado'); ?>">
+    <?php echo $bg_svg; ?>
     <g class="t" text-anchor="middle">
       <text class="t name" x="50%" y="155" font-size="90" id="<?php echo esc_attr($card_id); ?>">
         <tspan x="50%" dy="0"><?php echo esc_html($line1); ?></tspan>


### PR DESCRIPTION
## Summary
- Extract viewBox from background SVG and strip outer `<svg>` tags
- Use shared viewBox so background shapes scale properly inside employee card

## Testing
- `php -l templates/empleado-card-oct.php`
- `php -r '...default...'`
- `php -r '...custom...'`


------
https://chatgpt.com/codex/tasks/task_e_68c21441cac88327a338d3099c20ad22