### PR TITLE
Ensure configurator SVG fills preview container

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -15,3 +15,9 @@
     height: 200px;
     border: 1px solid #ccc;
 }
+
+#tarjeta_oct_bg_svg_display svg {
+    width: 100%;
+    height: 100%;
+    display: block;
+}


### PR DESCRIPTION
## Summary
- Extend admin.css to size and display configurator SVG at 100% within its 200x200 area

## Testing
- `npx -p puppeteer@22 node` *(fails: npm error 403 Forbidden when fetching puppeteer)*

------
https://chatgpt.com/codex/tasks/task_e_68c21623ab44832796dfda57befb0c5c