### PR TITLE
Prevent preview background tiling

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -21,6 +21,8 @@
         $preview.css({
             'color': ink,
             'background': bg,
+            'background-repeat': 'no-repeat',
+            'background-size': '100% 100%',
             'font-family': bodyStack
         });
         $preview.find('.cdb-preview-title').css('font-family', headStack);


### PR DESCRIPTION
## Summary
- ensure preview background does not tile and fits container

## Testing
- `node --check assets/js/admin.js`
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2180cbeb88327a768e4205dbafd31