### PR TITLE
Ensure proper SVG scaling in preview

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -9,15 +9,20 @@
     margin-top: 0;
 }
 #tarjeta_oct_bg_svg_display {
-    display: none;
     margin-top: 10px;
     width: 200px;
     height: 200px;
     border: 1px solid #ccc;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 #tarjeta_oct_bg_svg_display svg {
-    width: 100%;
-    height: 100%;
+    max-width: 100%;
+    max-height: 100%;
+    width: auto;
+    height: auto;
+    margin: auto;
     display: block;
 }

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -34,9 +34,25 @@
         });
         $('#tarjeta_oct_font_body, #tarjeta_oct_font_heading').on('change', updatePreview);
         $('#tarjeta_oct_bg_svg').on('input', updatePreview);
+        var $svgDisplay = $('#tarjeta_oct_bg_svg_display').hide();
         $('#tarjeta_oct_bg_svg_preview').on('click', function(){
-            var svg = $('#tarjeta_oct_bg_svg').val();
-            $('#tarjeta_oct_bg_svg_display').html(svg).toggle();
+            var svg = $('#tarjeta_oct_bg_svg').val().trim();
+            if(svg){
+                var doc = new DOMParser().parseFromString(svg, 'image/svg+xml');
+                var svgEl = doc.documentElement;
+                svgEl.removeAttribute('width');
+                svgEl.removeAttribute('height');
+                if(!svgEl.hasAttribute('preserveAspectRatio')){
+                    svgEl.setAttribute('preserveAspectRatio', 'xMidYMid meet');
+                }
+                $svgDisplay.html(svgEl.outerHTML);
+            } else {
+                $svgDisplay.empty();
+            }
+            $svgDisplay.toggle();
+            if($svgDisplay.is(':visible')){
+                $svgDisplay.css('display', 'flex');
+            }
         });
         updatePreview();
     });


### PR DESCRIPTION
## Summary
- Strip width/height from uploaded SVG previews, add preserveAspectRatio, and display via flexbox
- Center SVG preview and limit its size to fit within 200x200 box without distortion

## Testing
- `python - <<'PY'
import xml.etree.ElementTree as ET
container=(200,200)

def process(svg):
    root=ET.fromstring(svg)
    root.attrib.pop('width', None)
    root.attrib.pop('height', None)
    if 'preserveAspectRatio' not in root.attrib:
        root.set('preserveAspectRatio','xMidYMid meet')
    return root

def fit(viewBox, container):
    minx,miny,w,h = map(float, viewBox.split())
    cW,cH = container
    ratio = w/h
    cRatio = cW/cH
    if cRatio > ratio:
        final_h = cH
        final_w = final_h * ratio
    else:
        final_w = cW
        final_h = final_w / ratio
    return final_w, final_h

svgs=[
    '<svg width="500" height="250" viewBox="0 0 500 250"><rect width="500" height="250" fill="red"/></svg>',
    '<svg width="100" height="300" viewBox="0 0 100 300"><rect width="100" height="300" fill="blue"/></svg>'
]
for s in svgs:
    root=process(s)
    viewBox=root.attrib.get('viewBox')
    w,h=fit(viewBox,container)
    print(ET.tostring(root, encoding='unicode'))
    print('render size', w, h)
PY`
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c21be587cc83278dfc838308a791b0