### PR TITLE
Use contain background for preview

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -22,7 +22,8 @@
             'color': ink,
             'background': bg,
             'background-repeat': 'no-repeat',
-            'background-size': '100% 100%',
+            'background-size': 'contain',
+            'background-position': 'center',
             'font-family': bodyStack
         });
         $preview.find('.cdb-preview-title').css('font-family', headStack);


### PR DESCRIPTION
## Summary
- Prevent SVG distortion in employee preview by using `background-size: contain` and centering the background.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node - <<'NODE' ...` (simulated scaling check shows aspect ratio preserved)


------
https://chatgpt.com/codex/tasks/task_e_68c21fbb2a3c8327a820839462dfdf1f