### PR TITLE
Validate SVG before preview

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -38,18 +38,22 @@
         var $svgDisplay = $('#tarjeta_oct_bg_svg_display').hide();
         $('#tarjeta_oct_bg_svg_preview').on('click', function(){
             var svg = $('#tarjeta_oct_bg_svg').val().trim();
-            if(svg){
-                var doc = new DOMParser().parseFromString(svg, 'image/svg+xml');
-                var svgEl = doc.documentElement;
-                svgEl.removeAttribute('width');
-                svgEl.removeAttribute('height');
-                if(!svgEl.hasAttribute('preserveAspectRatio')){
-                    svgEl.setAttribute('preserveAspectRatio', 'xMidYMid meet');
-                }
-                $svgDisplay.html(svgEl.outerHTML);
-            } else {
-                $svgDisplay.empty();
+            if(!svg){
+                $svgDisplay.empty().hide();
+                return;
             }
+            var doc = new DOMParser().parseFromString(svg, 'image/svg+xml');
+            if(doc.documentElement.tagName === 'parsererror'){
+                alert('El SVG proporcionado no es válido.');
+                return;
+            }
+            var svgEl = doc.documentElement;
+            svgEl.removeAttribute('width');
+            svgEl.removeAttribute('height');
+            if(!svgEl.hasAttribute('preserveAspectRatio')){
+                svgEl.setAttribute('preserveAspectRatio', 'xMidYMid meet');
+            }
+            $svgDisplay.html(svgEl.outerHTML);
             $svgDisplay.toggle();
             if($svgDisplay.is(':visible')){
                 $svgDisplay.css('display', 'flex');


### PR DESCRIPTION
## Summary
- validate SVG markup with DOMParser before preview
- alert user and skip preview when parsing fails

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c222f4aee08327adcff68e90ad808b