### PR TITLE
Ensure SVG preview scales within admin panel

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -19,10 +19,9 @@
 }
 
 #tarjeta_oct_bg_svg_display svg {
-    max-width: 100%;
-    max-height: 100%;
-    width: auto;
-    height: auto;
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
     margin: auto;
     display: block;
 }

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -50,6 +50,12 @@
             var svgEl = doc.documentElement;
             svgEl.removeAttribute('width');
             svgEl.removeAttribute('height');
+            if(!svgEl.hasAttribute('viewBox') && svgEl.hasAttribute('width') && svgEl.hasAttribute('height')){
+                var w = svgEl.getAttribute('width'), h = svgEl.getAttribute('height');
+                svgEl.setAttribute('viewBox', '0 0 '+w+' '+h);
+            }
+            svgEl.setAttribute('width', '100%');
+            svgEl.setAttribute('height', '100%');
             if(!svgEl.hasAttribute('preserveAspectRatio')){
                 svgEl.setAttribute('preserveAspectRatio', 'xMidYMid meet');
             }


### PR DESCRIPTION
## Summary
- Adjust SVG preview logic to enforce responsive 100% width and height, adding fallback viewBox.
- Update admin CSS to scale SVG to the 200px preview box using object-fit.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c228208f448327b9bbf88ec697e8a7